### PR TITLE
[Proposal] Add interactive function switch-to-mrepl

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -714,6 +714,14 @@ Doesn't clear input history."
                                         'sly-mrepl-break-output t))
   (sly-message "Cleared recent output"))
 
+(defun sly-mrepl-switch-to-mrepl ()
+  "Switch to the last used mrepl."
+  (interactive)
+  (pop-to-buffer (cl-loop
+                  for buffer in (buffer-list)
+                  when (string-match "*sly-mrepl for " (buffer-name buffer))
+                  return buffer)))
+
 
 ;;; "External" non-interactive functions for plugging into
 ;;; other parts of SLY


### PR DESCRIPTION
Currently C-c C-z switches to the lisp inferior process, which is not of much use. Because there might be multiple REPL's I think a simple solution is to just return the last used one.

IMHO the binding in lisp-mode-map should also be overridden.

``` elisp
(define-key lisp-mode-map (kbd "C-c C-z") 'sly-mrepl-switch-to-mrepl)
```
