### PR TITLE
* sly.el: Add sly-macroexpand

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -4781,10 +4781,12 @@ argument is given, with CL:MACROEXPAND."
   (sly-eval-macroexpand-inplace
    (if repeatedly 'slynk:slynk-macroexpand 'slynk:slynk-macroexpand-1)))
 
-(defun sly-macroexpand-all ()
+(defun sly-macroexpand-all (&optional just-one)
   "Display the recursively macro expanded sexp at point."
-  (interactive)
-  (sly-eval-macroexpand 'slynk:slynk-macroexpand-all))
+  (interactive "P")
+  (sly-eval-macroexpand (if just-one
+                            'swank:swank-macroexpand-1
+                          'slynk:slynk-macroexpand-all)))
 
 (defun sly-macroexpand-all-inplace ()
   "Display the recursively macro expanded sexp at point."


### PR DESCRIPTION
Oi,
   Currently there is no keybinding to macroexpand an expression once. I figured that adding a negative argument to C-c M-m would be a good place to add one.

I realize that this function is the same of `sly-macroexpand-1` expect it toggles the other way around so maybe you want to add the functionality another way to prevent duplicated code?
