### PR TITLE
Update refcard docs and cross-reference sections

### DIFF
--- a/doc/sly-refcard.tex
+++ b/doc/sly-refcard.tex
@@ -43,22 +43,22 @@
 \subgroup{Documentation}
 
 \key{spc}{insert a space, display argument list}
-\key{C-c C-d d}{describe symbol}
-\key{C-c C-f}{describe function}
-\key{C-c C-d a}{apropos search for regexp}
-\key{C-c C-d z}{apropos with internal symbols}
-\key{C-c C-d p}{apropos in package}
-\key{C-c C-d h}{hyperspec lookup}
-\key{C-c C-d ~}{format character hyperspec lookup}
+\key{C-c C-d C-d}{describe symbol}
+\key{C-c C-d C-f}{describe function}
+\key{C-c C-d C-a}{apropos search for regexp}
+\key{C-c C-d C-z}{apropos with internal symbols}
+\key{C-c C-d C-p}{apropos in package}
+\key{C-c C-d C-h}{hyperspec lookup}
+\key{C-c C-d C-\~}{format character hyperspec lookup}
 
 
 \subgroup{Cross reference}
 
-\key{C-c C-w c}{show function callers}
-\key{C-c C-w r}{show references to global variable}
-\key{C-c C-w b}{show bindings of a global variable}
-\key{C-c C-w s}{show assignments to a global variable}
-\key{C-c C-w m}{show expansions of a macro}
+\key{C-c C-w C-c}{show function callers}
+\key{C-c C-w C-r}{show references to global variable}
+\key{C-c C-w C-b}{show bindings of a global variable}
+\key{C-c C-w C-s}{show assignments to a global variable}
+\key{C-c C-w C-m}{show expansions of a macro}
 \key{C-c \textless}{list callers of a function}
 \key{C-c \textgreater}{list callees of a function}
 


### PR DESCRIPTION
Update the keymaps in the documentation and cross-reference sections
of the refcard to match the current default maps in the code.
