### PR TITLE
Slynk completion refactor

### DIFF
--- a/slynk/slynk-backend.lisp
+++ b/slynk/slynk-backend.lisp
@@ -255,6 +255,13 @@ This will be used like so:
       '(:and)
       '(:or)))
 
+;; Copied verbatim from Alexandria.
+(defun mappend (function &rest lists)
+  "Applies FUNCTION to respective element(s) of each LIST, appending all the
+all the result list to a single list. FUNCTION must return a list."
+  (loop for results in (apply #'mapcar function lists)
+        append results))
+
 
 ;;;; UFT8
 

--- a/slynk/slynk-completion.lisp
+++ b/slynk/slynk-completion.lisp
@@ -253,17 +253,16 @@ Returns a list of (COMPLETIONS NIL). COMPLETIONS is a list of
               for (string symbol indexes score)
                 in
                 (remove-duplicates
-                 (loop with (external internal)
-                         = (multiple-value-list (qualified-matching pattern package))
-                       for e in (append (sort-by-score
-                                         (keywords-matching pattern))
-                                        (sort-by-score
-                                         (append (accessible-matching pattern package)
-                                                 external))
-                                        (sort-by-score
-                                         internal))
-                       for i upto limit
-                       collect e)
+                 (multiple-value-bind (external internal) (qualified-matching pattern package)
+                   (loop for e in (append (sort-by-score
+                                           (keywords-matching pattern))
+                                          (sort-by-score
+                                           (append (accessible-matching pattern package)
+                                                   external))
+                                          (sort-by-score
+                                           internal))
+                         for i upto limit
+                         collect e))
                  :from-end t
                  :test #'string=
                  :key #'first)

--- a/slynk/slynk-completion.lisp
+++ b/slynk/slynk-completion.lisp
@@ -5,6 +5,7 @@
 ;;
 (defpackage :slynk-completion
   (:use #:cl #:slynk-api)
+  (:import-from #:slynk-backend #:when-let)
   (:export
    #:flex-completions
    #:simple-completions))
@@ -164,40 +165,40 @@ Returns two values: \(A B C\) and \(1 2 3\)."
   (and (not (char= (aref pattern 0) #\:))
        (collecting (collect-external collect-internal)
          (do-all-symbols (s)
-           (let* ((symbol-package (symbol-package s))
-                  (nicknames (package-nicknames symbol-package))
-                  (sorted-nicknames (sort (cons (package-name symbol-package)
-                                                (copy-list nicknames))
-                                          #'<
-                                          :key #'length)))
-             (when (and (not (excluded-from-searches-p s))
-                        ;; keyword symbols are handled explicitly by
-                        ;; `keyword-matching', so don't repeat them here.
-                        ;; 
-                        (and (not (eq (find-package :keyword)
-                                      symbol-package))))
-               (loop ;; TODO: add package-local nicknames: `package' might
-                     ;; now `symbol-package' under more nicknames. They
-                     ;; should be added and perhaps also sorted according to
-                     ;; length.
-                     ;;
-                     for nickname in sorted-nicknames
-                     for external-p = (slynk::symbol-external-p s)
-                     do
-                        (cond (external-p
-                               (collect-maybe #'collect-external
-                                              pattern
-                                              (format nil "~a:~a"
-                                                      nickname
-                                                      (symbol-name s))
-                                              s))
-                              (t
-                               (collect-maybe #'collect-internal
-                                              pattern
-                                              (format nil "~a::~a"
-                                                      nickname
-                                                      (symbol-name s))
-                                              s))))))))))
+           (when-let (symbol-package (symbol-package s))
+             (let* ((nicknames (package-nicknames symbol-package))
+                    (sorted-nicknames (sort (cons (package-name symbol-package)
+                                                  (copy-list nicknames))
+                                            #'<
+                                            :key #'length)))
+               (when (and (not (excluded-from-searches-p s))
+                          ;; keyword symbols are handled explicitly by
+                          ;; `keyword-matching', so don't repeat them here.
+                          ;;
+                          (and (not (eq (find-package :keyword)
+                                        symbol-package))))
+                 (loop ;; TODO: add package-local nicknames: `package' might
+                       ;; now `symbol-package' under more nicknames. They
+                       ;; should be added and perhaps also sorted according to
+                       ;; length.
+                       ;;
+                       for nickname in sorted-nicknames
+                       for external-p = (slynk::symbol-external-p s)
+                       do
+                          (cond (external-p
+                                 (collect-maybe #'collect-external
+                                                pattern
+                                                (format nil "~a:~a"
+                                                        nickname
+                                                        (symbol-name s))
+                                                s))
+                                (t
+                                 (collect-maybe #'collect-internal
+                                                pattern
+                                                (format nil "~a::~a"
+                                                        nickname
+                                                        (symbol-name s))
+                                                s)))))))))))
 
 (defslyfun flex-completions (pattern package-name &key (limit 300))
   "Return \"flex\"completions for PATTERN.

--- a/slynk/slynk-util.lisp
+++ b/slynk/slynk-util.lisp
@@ -60,4 +60,3 @@ boundp fboundp generic-function class macro special-operator package"
       (when (find-package symbol)       (flip #\p))
       result)))
 
-(provide :slynk-util)


### PR DESCRIPTION
Joao,

This is more a WIP branch to request feedback. Although everything except the last commit could be merged.

The refactor qualified-matching cannot be merged as it now honours the package argument, so when trying to complete patterns such as `"alexandria:map"` it returns nil because it doesn't break the pattern to look for "map" on the package alexandria. I would like to process the pattern according the [notes found in slime's compound-style-completion](https://github.com/slime/slime/blob/master/contrib/swank-c-p-c.lisp#L122) and use that information to call qualified-matching(-1?). My idea is to split the pattern on `#\:` at the start `flex-completions`. If there is no `#\:` continue the current behaviour. If found, the first part of the pattern would be matched against all packages. Only if at least a character of the pattern is found in the package name, nickname or package-local-nickname (see below) would the package be considered and then qualified-matching-1 be called with the string to the right of the `#\:` and each matching candidate for the package pattern. What do you think of that behaviour?
### Flex-match

As noted in the package documentation option, the matching algorithm used has some weird edge cases, as the one shown below. The completion score imho should be 0. It most certainly not return 100% for same length candidates.

``` lisp
(let ((pattern "a")
      (candidate "identity"))
  (score-completion (flex-matches pattern candidate)
                    pattern
                    candidate))
;; => 0.125 (12.5%)

(let ((pattern "a")
      (candidate "i"))
  (score-completion (flex-matches pattern candidate)
                    pattern
                    candidate))
;; => 1.0 (100.0%)
```
### Assorted questions
- Where do you prefer a c-p-c version to be placed in? a contrib or as part of slynk folder. I want to be have a function akin to `'sly-c-pc-replace-thing-at-point` to ease writing stuff like multiple-value-bind (m-v-b) or destructuring-bind (d-b).
- Although I've yet to look at the elisp side, would it be desirable to present a 'hookable UI' for completion? How to present the candidates to the user to be modifiable through customization, so the minibuffer or a tooltip, but the candidates would be the same.
- is the -1 suffix the proper idiom in this case? AFAIU it is used to refer to versions of function that do one 'unit for work' of the sans suffix version.
