### PR TITLE
.gitignore: Ignore ABCL uncompressed FASLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ ChangeLog
 *.lx64fsl
 *.dx64fsl
 *.elc
+*.cls
 *~
 \#*\#
 .\#*


### PR DESCRIPTION
Another temporary file created when compiling a file with ABCL is <file-name-with-extension>-tmp, but that seemed generic enough