### PR TITLE
Allow the user to customize where the input history is saved

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -81,6 +81,10 @@ emptied. See also `sly-mrepl-hook'")
 This variables behaves like `comint-preoutput-filter-functions',
 for output printed to the REPL (not for evaluation results)")
 
+(defcustom sly-mrepl-history-file-name (expand-file-name "~/.sly-mrepl-history")
+  "The file used to store MREPL's input history across sessions."
+  :group 'sly)
+
 (defvar sly-mrepl-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "RET")     'sly-mrepl-return)
@@ -145,7 +149,7 @@ for output printed to the REPL (not for evaluation results)")
                 (comint-output-filter-functions nil)
                 (comint-input-filter-functions nil)
                 (comint-history-isearch dwim)
-                (comint-input-ring-file-name "~/.sly-mrepl-history")
+                (comint-input-ring-file-name ,sly-mrepl-history-file-name)
                 (comint-input-ignoredups t)
                 (comint-prompt-read-only t)
                 (indent-line-function lisp-indent-line)


### PR DESCRIPTION
Not sure is using `expand-file-name` is appropriate but if Emacs expands the path appropriately we don't have to rely on how CL implementations handle ~/ in the path.

* sly-mrepl.el (sly-mrepl-history-file-name): Add new variable
(sly-mrepl-mode-map): Use sly-mrepl-history-file-name instead of
  hard-coded path

Closes #101