### PR TITLE
Fix post-command-hook error after using #v

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1249,12 +1249,12 @@ a list of result buttons thus highlighted"
                                                entry-idx)
                                 (format "Matched history entry %s%s: "
                                              entry-idx
-                                             (if (rest buttons)
+                                             (if (cl-rest buttons)
                                                  (format " (%s values)" (length buttons))
                                                ""))))
                       (hint (propertize
                              (truncate-string-to-width
-                              (replace-regexp-in-string "\n" " " (button-label (first buttons)))
+                              (replace-regexp-in-string "\n" " " (button-label (cl-first buttons)))
                               (- (window-width (minibuffer-window))
                                  (length prefix) 10)
                               nil


### PR DESCRIPTION
* sly-mrepl.el (sly-mrepl--highlight-backreferences-maybe): use cl-first and cl-rest

When trying out #v<n> I found that the first time, a post-command-hook
error would fire to the effect that rest was an unknown function, after
which the #v mechanism was slightly broken. I was using emacs -q in 
order to isolate any problems I was having with my config, consequently 
I had not loaded cl-lib. I tracked it down to sly-mrepl.el.