### PR TITLE
Don't force numbers to be printed as decimal

### DIFF
--- a/slynk/slynk.lisp
+++ b/slynk/slynk.lisp
@@ -2014,9 +2014,9 @@ same as that variable.")
                  when display collect it
                    until skip)))
     (if extra-presentations
-        (format nil "~D (~{~a~^, ~})"
+        (format nil "~A (~{~a~^, ~})"
                 number extra-presentations)
-        (format nil "~D" number))))
+        (format nil "~A" number))))
 
 (defun echo-for-emacs (values)
   "Format VALUES in a way suitable to be echoed in the SLY client"


### PR DESCRIPTION
By using the Decimal directive we force numbers to be printed as decimal,
ignoring the value of *print-base*, using the Aesthetic directive prints the
number respecting *print-base*.

* slynk/slynk.lisp (present-number-considering-alist): Use Aesthetic directive
  instead the Decimal directive

<hr />

Btw, I am aware that sly provides a more complete way to configure how to print numbers in `SLYNK:*ECHO-NUMBER-ALIST*` and `SLYNK:*PRESENT-NUMBER-ALIST*` and they seem better suited for a long term need, for instance they can present multiple information about the number at once. But I don't think that providing this mechanism should ignore the language built-in ones.
