### PR TITLE
Also export the flexible completion function from the Slynk package

### DIFF
--- a/slynk/slynk-completion.lisp
+++ b/slynk/slynk-completion.lisp
@@ -233,4 +233,8 @@ Returns a list of (COMPLETIONS NIL). COMPLETIONS is a list of
                     (slynk::symbol-classification-string symbol)))
             nil))))
 
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (import 'flex-completions :slynk)
+  (export 'flex-completions :slynk))
+
 (provide :slynk-completion)


### PR DESCRIPTION
To use the flexible completion function in Emacs, one has to refer to this particular package as the function is not exported from the Slynk package. This is probably bad for maintainability.