### PR TITLE
Recursive ASDF loading breaks M-x sly in very recent ASDF (bundled with very recent SBCL)

### DIFF
--- a/contrib/slynk-fancy-inspector.lisp
+++ b/contrib/slynk-fancy-inspector.lisp
@@ -6,8 +6,6 @@
 
 (in-package :slynk)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (slynk-require :slynk-util))
 
 (defmethod emacs-inspect ((symbol symbol))
   (let ((package (symbol-package symbol)))

--- a/contrib/slynk-mrepl.lisp
+++ b/contrib/slynk-mrepl.lisp
@@ -97,7 +97,7 @@ Set this to NIL to turn this feature off.")
   (declare (ignore subchar arg))
   (let* ((*readtable*
            (let ((table (copy-readtable nil)))
-             (set-macro-character #\: (lambda (&rest args) nil) nil table)
+             (set-macro-character #\: (constantly nil) nil table)
              table))
          (entry-idx
            (progn


### PR DESCRIPTION
Updated SBCL to current head today (after many moons) and sly wouldn't load. This fixes the error shown below.

![image](https://user-images.githubusercontent.com/387111/32639115-4fa8beb4-c590-11e7-970c-6a5fb1ecf23a.png)

Emacs version: GNU Emacs 25.2.2 (x86_64-unknown-linux-gnu, GTK+ Version 3.18.9) of 2017-05-25