### PR TITLE
delete window after selecting new window in pop-to-source-location

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -3538,14 +3538,14 @@ If called from an xref buffer, method will be `sly-xref' and
 thus also honour `sly-xref--popup-method'."
   (let* ((xref-window (selected-window))
          (xref-buffer (window-buffer xref-window)))
-    (when (eq method 'sly-xref)
-      (quit-window nil xref-window))
     (with-current-buffer xref-buffer
       ;; now pop to target
       ;;
       (select-window
        (sly--display-source-location source-location nil method)))
-    (set-buffer (window-buffer (selected-window)))))
+    (set-buffer (window-buffer (selected-window)))
+    (when (eq method 'sly-xref)
+      (quit-window nil xref-window))))
 
 (defun sly-location-offset (location)
   "Return the position, as character number, of LOCATION."


### PR DESCRIPTION
This fixes frequent 'Selecting deleted buffer' messages for me under
emacs 25.2.3.

Full disclosure: I have spent literally two minutes on this and have never looked into the sly/slime code in any  meaningful way. I am also not experienced in elisp. It does fix the error message and also makes kind of sense to keep as long as you depend on it.