### PR TITLE
Added function sly-import-symbol-at-point to add import-from into thecurrent defpackage form

### DIFF
--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -338,8 +338,6 @@ symbol in the Lisp image if possible."
 ;; 
 ;; Dealing with import-from
 ;;
-;; MELPA version: (buffer-substring-no-properties point1 pount2)
-;; ~/.emacs.d/elpa/sly-20171111.1604/contrib/sly-package-fu.el
 
 (defun sly-search-import-from (package)
   ;; Suppose, we are in the defpackage sexp

--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -372,8 +372,14 @@ symbol in the Lisp image if possible."
     (t (error "Unable to find :use form in the defpackage form."))))
 
 
-(defun sly-import-symbol-from (symbol)
-  "Accepts "
+(defun sly-package-fu--add-or-update-import-from-form (symbol)
+  "Accepts a string or a symbol like \"alexandria:with-gensyms\",
+   and adds it to existing (import-from #:alexandria ...) form
+   or creates a new one.
+
+   Returns a name of the given symbol inside of it's package.
+   For example above, it will return \"with-gensyms\"."
+  
   (save-excursion
    ;; First, will go to the package definition
    (sly-goto-package-source-definition (sly-current-package))
@@ -424,7 +430,8 @@ symbol in the Lisp image if possible."
                 (buffer-substring-no-properties left-bound
                                                 right-bound))
               (simple-symbol
-                (sly-import-symbol-from symbol-name)))
+                (sly-package-fu--add-or-update-import-from-form
+                 symbol-name)))
          ;; If symbol was imported, then we need to replace
          ;; fully qualified symbol name with simple one:
          (when simple-symbol

--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -339,7 +339,7 @@ symbol in the Lisp image if possible."
 ;; Dealing with import-from
 ;;
 
-(defun sly-search-import-from (package)
+(defun sly-package-fu--search-import-from (package)
   ;; Suppose, we are in the defpackage sexp
   (let* ((normalized-package (sly-package-normalize-name package))
          (regexp (format "(:import-from[ \t']*\\(:\\|#:\\)?%s"
@@ -401,7 +401,7 @@ symbol in the Lisp image if possible."
                             (sly-cl-symbol-package symbol)))
           (simple-symbol (sly-cl-symbol-name symbol))
           (import-exists (when package
-                           (sly-search-import-from package))))
+                           (sly-package-fu--search-import-from package))))
 
      ;; We only process symbols in fully qualified form like
      ;; weblocks/request:get-parameter

--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -404,7 +404,6 @@ symbol in the Lisp image if possible."
                               :test 'equalp)
              ;; If symbol is not imported yet, then just
              ;; add it to the end
-             ;; TODO: rename function
              (sly-package-fu--insert-symbol simple-symbol)))
          ;; If there is no import from this package yet,
          ;; then we'll add it right after the last :import-from

--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -216,7 +216,7 @@ already exported/unexported."
            (let ((symbol-name (sly-cl-symbol-name symbol)))
              (unless (sly-symbol-exported-p symbol-name exported-symbols)
                (cl-incf number-of-actions)
-               (sly-insert-export symbol-name)))))
+               (sly-package-fu--insert-symbol symbol-name)))))
         (:unexport
          (dolist (symbol symbols)
            (let ((symbol-name (sly-cl-symbol-name symbol)))
@@ -273,8 +273,9 @@ already exported/unexported."
              sly-export-symbol-representation-function)
            symbol-name))
 
-(defun sly-insert-export (symbol-name)
-  ;; Assumes we're at the inside :export after the last symbol
+(defun sly-package-fu--insert-symbol (symbol-name)
+  ;; Assumes we're at the inside :export or :import-from form
+  ;; after the last symbol
   (let ((symbol-name (sly-format-symbol-for-defpackage symbol-name)))
     (unless (looking-back "^\\s-*" (line-beginning-position) nil)
       (newline-and-indent))
@@ -404,7 +405,7 @@ symbol in the Lisp image if possible."
              ;; If symbol is not imported yet, then just
              ;; add it to the end
              ;; TODO: rename function
-             (sly-insert-export simple-symbol)))
+             (sly-package-fu--insert-symbol simple-symbol)))
          ;; If there is no import from this package yet,
          ;; then we'll add it right after the last :import-from
          ;; or :use construction

--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -352,7 +352,7 @@ symbol in the Lisp image if possible."
       t)))
 
 
-(defun sly-package-create-new-import-from (package symbol)
+(defun sly-package-fu--create-new-import-from (package symbol)
   (sly-goto-package-source-definition (sly-current-package))
   (forward-sexp)
   ;; Now, search last :import-from or :use form
@@ -400,8 +400,8 @@ symbol in the Lisp image if possible."
            ;; If there is no import from this package yet,
            ;; then we'll add it right after the last :import-from
            ;; or :use construction
-           (sly-package-create-new-import-from package
-                                               simple-symbol)))
+           (sly-package-fu--create-new-import-from package
+                                                   simple-symbol)))
      ;; Always return symbol-without-package, because it is useful
      ;; to replace symbol at point and change it from fully qualified
      ;; form to a simple-form

--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -352,25 +352,6 @@ symbol in the Lisp image if possible."
       t)))
 
 
-(defun sly-package-write-imported (symbol)
-  "Like rites given symbol to the end of the :import-from clause.
-
-   Expects that current point is right after the last symbol
-   in the :import-from sexp:
-
-   (:import-from #:weblocks/requests
-                 #:get-parameters<point>)"
-
-  (goto-char point)
-  (down-list)
-  (sly-end-of-list))
-
-
-(defun get-piece (chars)
-  (buffer-substring-no-properties (point)
-                                  (+ (point)
-                                     chars)))
-
 (defun sly-package-create-new-import-from (package symbol)
   (sly-goto-package-source-definition (sly-current-package))
   (forward-sexp)

--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -392,22 +392,24 @@ symbol in the Lisp image if possible."
 
      ;; We only process symbols in fully qualified form like
      ;; weblocks/request:get-parameter
-     (when package
-       (if import-exists
-           (let ((imported-symbols (mapcar #'sly-package-normalize-name
-                                           (sly-package-fu--read-symbols))))
-             (unless (cl-member simple-symbol
-                                imported-symbols
-                                :test 'equalp)
-               ;; If symbol is not imported yet, then just
-               ;; add it to the end
-               ;; TODO: rename function
-               (sly-insert-export simple-symbol)))
-           ;; If there is no import from this package yet,
-           ;; then we'll add it right after the last :import-from
-           ;; or :use construction
-           (sly-package-fu--create-new-import-from package
-                                                   simple-symbol)))
+     (unless package
+       (user-error "This only works on symbols with package designator."))
+     
+     (if import-exists
+         (let ((imported-symbols (mapcar #'sly-package-normalize-name
+                                         (sly-package-fu--read-symbols))))
+           (unless (cl-member simple-symbol
+                              imported-symbols
+                              :test 'equalp)
+             ;; If symbol is not imported yet, then just
+             ;; add it to the end
+             ;; TODO: rename function
+             (sly-insert-export simple-symbol)))
+         ;; If there is no import from this package yet,
+         ;; then we'll add it right after the last :import-from
+         ;; or :use construction
+         (sly-package-fu--create-new-import-from package
+                                                 simple-symbol))
      ;; Always return symbol-without-package, because it is useful
      ;; to replace symbol at point and change it from fully qualified
      ;; form to a simple-form

--- a/sly.el
+++ b/sly.el
@@ -7077,10 +7077,10 @@ The result is unspecified if there isn't a symbol under the point."
   "Return the bounds of the symbol around point.
 The returned bounds are either nil or non-empty."
   (let ((bounds (bounds-of-thing-at-point 'sly-symbol)))
-    (if (and bounds
-             (< (car bounds)
-                (cdr bounds)))
-        bounds)))
+    (when (and bounds
+               (< (car bounds)
+                  (cdr bounds)))
+      bounds)))
 
 (defun sly-symbol-at-point ()
   "Return the name of the symbol at point, otherwise nil."

--- a/sly.el
+++ b/sly.el
@@ -7077,7 +7077,7 @@ The result is unspecified if there isn't a symbol under the point."
   "Return the bounds of the symbol around point.
 The returned bounds are either nil or non-empty."
   (let ((bounds (bounds-of-thing-at-point 'sly-symbol)))
-    (when (and bounds
+    (if (and bounds
                (< (car bounds)
                   (cdr bounds)))
       bounds)))

--- a/sly.el
+++ b/sly.el
@@ -7078,9 +7078,9 @@ The result is unspecified if there isn't a symbol under the point."
 The returned bounds are either nil or non-empty."
   (let ((bounds (bounds-of-thing-at-point 'sly-symbol)))
     (if (and bounds
-               (< (car bounds)
-                  (cdr bounds)))
-      bounds)))
+             (< (car bounds)
+                (cdr bounds)))
+        bounds)))
 
 (defun sly-symbol-at-point ()
   "Return the name of the symbol at point, otherwise nil."


### PR DESCRIPTION
This function is bound to C-c i by default, and using it, you can easily simplify
your code by moving package prefixes into the defpackage form.

Here is a demo:

https://youtu.be/pZ72_hI4Tcw
