### PR TITLE
Update sly-tramp to be compatible with emacs 26

### DIFF
--- a/contrib/sly-tramp.el
+++ b/contrib/sly-tramp.el
@@ -55,16 +55,30 @@ See also `sly-create-filename-translator'."
         (t (list #'identity #'identity))))
 
 (defun sly-make-tramp-file-name (username remote-host lisp-filename)
-  "Old (with multi-hops) tramp compatability function"
-  (if (boundp 'tramp-multi-methods)
-      (tramp-make-tramp-file-name nil nil
-                                  username
-                                  remote-host
-                                  lisp-filename)
-      (tramp-make-tramp-file-name nil
-                                  username
-                                  remote-host
-                                  lisp-filename)))
+  "Tramp compatability function.
+
+Handles the signature of `tramp-make-tramp-file-name' changing
+over time."
+  (cond
+   ((>= emacs-major-version 26)
+    ;; Emacs 26 requires the method to be provided and the signature of
+    ;; `tramp-make-tramp-file-name' has changed.
+    (tramp-make-tramp-file-name (tramp-find-method nil username remote-host)
+                                username
+                                nil
+                                remote-host
+                                nil
+                                lisp-filename))
+   ((boundp 'tramp-multi-methods)
+    (tramp-make-tramp-file-name nil nil
+                                username
+                                remote-host
+                                lisp-filename))
+   (t
+    (tramp-make-tramp-file-name nil
+                                username
+                                remote-host
+                                lisp-filename))))
 
 (cl-defun sly-create-filename-translator (&key machine-instance
                                                  remote-host


### PR DESCRIPTION
This updates `sly-tramp.el` to work with emacs 26, as taken from slime!

The fix is taken from slime/slime@114bc26.