### PR TITLE
Fix Hash Table Inspector with Complex Numbers as keys

### DIFF
--- a/slynk/slynk.lisp
+++ b/slynk/slynk.lisp
@@ -3668,7 +3668,7 @@ Return NIL if LIST is circular."
    (let ((content (hash-table-to-alist ht)))
      (cond ((every (lambda (x) (typep (first x) '(or string symbol))) content)
             (setf content (sort content 'string< :key #'first)))
-           ((every (lambda (x) (typep (first x) 'number)) content)
+           ((every (lambda (x) (typep (first x) 'real)) content)
             (setf content (sort content '< :key #'first))))
      (loop for (key . value) in content appending
            `((:value ,key) " = " (:value ,value)


### PR DESCRIPTION
The EMACS-INSPECT method that specialized on HASH-TABLE tries to order
the contents of the hash-table before to present them in order. However
it incorrectly applies the function < if the contents are NUMBERs. Only =
and /= are defined for NUMBERS. < and the other comparison functions
apply only to REALs. Because this feature is an extra nicety fix the bug
by not ordering the contents in the presences of COMPLEX numbers.

To reproduce the bug inspect the hash table from return by

(let ((ht (make-hash-table)))
  (setf (gethash #C(0 1) ht) t
            (gethash #C(0 2) ht) t)
  ht)