### PR TITLE
Tramp filename translator was fixed

### DIFF
--- a/contrib/sly-tramp.el
+++ b/contrib/sly-tramp.el
@@ -86,8 +86,11 @@ The functions created here expect your tramp-default-method or
                 (username (or username (user-login-name))))
     (list (concat "^" machine-instance "$")
           (lambda (emacs-filename)
-            (tramp-file-name-localname
-             (tramp-dissect-file-name emacs-filename)))
+            (cond
+              ((tramp-file-name-p emacs-filename)
+               (tramp-file-name-localname
+                (tramp-dissect-file-name emacs-filename)))
+              (t emacs-filename)))
           `(lambda (lisp-filename)
              (sly-make-tramp-file-name
               ,username


### PR DESCRIPTION
When using SLY's tramp contrib, you can edit not only files opened
via tramp but also local sources. Before this patch, in the latter case,
Emacs printed "Tramp file name: /Users/art/projects/..." error.

Now, tramp contrib can work both with the tramp and plain filenames.