### PR TITLE
Change sly-version to always return version

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -222,8 +222,8 @@ If FILE is passed use that instead to discover the version."
                    ";;[[:space:]]*Version:[[:space:]]*\\(.*\\)$" nil t)
                   (match-string 1)))))
       (if interactive
-          (sly-message "SLY %s" version)
-        version))))
+          (sly-message "SLY %s" version))
+        version)))
 
 (defvar sly-protocol-version nil)
 


### PR DESCRIPTION
Was having trouble with the protocol-version with sly freshly installed from MELPA. It seems that when (sly-version) is called non interactively it doesn't return a version and so was giving an arbitrary string or nil