### PR TITLE
sly-mrepl: Prompt with most recently used shortcut

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1215,11 +1215,15 @@ When setting this variable outside of the Customize interface,
                                       (mapcar #'car sly-mrepl-shortcut-alist)
                                       nil
                                       'require-match))
-         (command (and string
-                       (cdr (assoc string sly-mrepl-shortcut-alist)))))
+         (item (and string (assoc string sly-mrepl-shortcut-alist)))
+         (command (cdr item)))
+    ;; Move the most recently used shortcut to the head of the shortcut list
+    (setf sly-mrepl-shortcut-alist
+          (cons item
+                (cl-remove item sly-mrepl-shortcut-alist)))
     (call-interactively command)))
 
-
+
 ;;; Backreference highlighting
 ;;;
 (defvar sly-mrepl--backreference-overlays nil

--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1194,6 +1194,7 @@ When setting this variable outside of the Customize interface,
     ("set directory"  . sly-mrepl-set-directory)
     ("set package"    . sly-mrepl-set-package)))
 
+(defvar sly-mrepl-history nil "History of `sly-mrepl-shortcut' commands.")
 
 (defun sly-mrepl-set-package ()
   (interactive)
@@ -1214,16 +1215,13 @@ When setting this variable outside of the Customize interface,
   (let* ((string (sly-completing-read "Command: "
                                       (mapcar #'car sly-mrepl-shortcut-alist)
                                       nil
-                                      'require-match))
-         (item (and string (assoc string sly-mrepl-shortcut-alist)))
-         (command (cdr item)))
-    ;; Move the most recently used shortcut to the head of the shortcut list
-    (setf sly-mrepl-shortcut-alist
-          (cons item
-                (cl-remove item sly-mrepl-shortcut-alist)))
+                                      'require-match nil 'sly-mrepl-history
+                                      (car sly-mrepl-history)))
+         (command (and string
+                       (cdr (assoc string sly-mrepl-shortcut-alist)))))
     (call-interactively command)))
 
-
+
 ;;; Backreference highlighting
 ;;;
 (defvar sly-mrepl--backreference-overlays nil


### PR DESCRIPTION
@joaotavora WDYT of adding a little bit of logic to bring the last used repl shortcut to the head of the shortcut alist? Results in `sly-mrepl-shortcut` prompting with the last used shortcut. 

![bring-top-top](https://user-images.githubusercontent.com/16738762/59328027-35655480-8ca0-11e9-9f6f-5a9cdcce26cc.gif)
