### PR TITLE
Fix #243: indent UIOP:DEFINE-PACKAGE like CL:DEFPACKAGE

### DIFF
--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -48,6 +48,8 @@ use `sly-export-symbol-representation-function'.")
 (defvar sly-defpackage-regexp
   "^(\\(cl:\\|common-lisp:\\|uiop:\\|\\uiop/package:\\)?\\(defpackage\\|define-package\\)\\>[ \t']*")
 
+(put 'uiop:define-package 'common-lisp-indent-function '(as defpackage))
+
 (defun sly-find-package-definition-rpc (package)
   (sly-eval `(slynk:find-definition-for-thing
                 (slynk::guess-package ,package))))


### PR DESCRIPTION
* contrib/sly-package-fu.el (uiop:define-package): Use a
reasonable indentation spec.