### PR TITLE
Fixed a bug with evaluating a form from a file opened via ssh and Tramp.

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1051,7 +1051,7 @@ prefix argument is given."
     (sly-mrepl--eval-for-repl
      `(slynk-mrepl:sync-package-and-default-directory
        :package-name ,package
-       :directory ,directory)
+       :directory ,(sly-to-lisp-filename directory))
      :insert-p nil
      :before-prompt
      #'(lambda (results)

--- a/sly.el
+++ b/sly.el
@@ -983,7 +983,15 @@ macroexpansion time.
 
 (defun sly-to-lisp-filename (filename)
   "Translate the string FILENAME to a Lisp filename."
-  (funcall sly-to-lisp-filename-function filename))
+  (let ((filename (copy-sequence filename)))
+    ;; We need to remove properties from filename
+    ;; because it text with properties will
+    ;; have wrong syntax when translated into a
+    ;; Common Lisp's form.
+    (set-text-properties 0 (length filename)
+                         nil
+                         filename)
+    (funcall sly-to-lisp-filename-function filename)))
 
 (defun sly-from-lisp-filename (filename)
   "Translate the Lisp filename FILENAME to an Emacs filename."


### PR DESCRIPTION
Previously, Slynk interrupted a connection after the form evaluation.

This pull fixes issue https://github.com/joaotavora/sly/issues/256