### PR TITLE
Ensure - is defined within the running form.

### DIFF
--- a/contrib/slynk-mrepl.lisp
+++ b/contrib/slynk-mrepl.lisp
@@ -252,10 +252,11 @@ Set this to NIL to turn this feature off.")
                                          table)))
                       (read in nil in))
                     until (eq form in)
-                    do (setq values (multiple-value-list
-                                     (eval
-                                      (saving-listener-bindings repl
-                                        (setq +++ ++ ++ + + form)))))
+                    do (let ((- form))
+                         (setq values (multiple-value-list
+                                       (eval
+                                        (saving-listener-bindings repl
+                                          (setq +++ ++ ++ + + form))))))
                     finally
                     (return values))))
         (setf (cdr (assoc '*package* (slot-value repl 'slynk::env)))

--- a/slynk/slynk.lisp
+++ b/slynk/slynk.lisp
@@ -1504,8 +1504,8 @@ event was found."
    (force-output)
    (let ((form (handler-case (read)
                  (end-of-repl-input () (return)))))
-     (let ((- form)
-           (values (multiple-value-list (eval form))))
+     (let* ((- form)
+            (values (multiple-value-list (eval form))))
        (setq *** **  ** *  * (car values)
              /// //  // /  / values
              +++ ++  ++ +  + form)


### PR DESCRIPTION
Resolve #288 

Defines `-` inside the running form, instead of leaving it free, but only for a slynk `simple-repl`. I had some help from `bike` and `pjb` on `#lisp` for this one.

I'm not sure what code is getting run for a normal REPL.