### PR TITLE
Prefix argument to sly-switch-to-most-recent fails to prompt.

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -2749,7 +2749,7 @@ Debugged requests are ignored."
   "Switch to most recent buffer in MODE, a major-mode symbol.
 With prefix argument, prompt for MODE"
   (interactive
-   (list (if prefix-arg
+   (list (if current-prefix-arg
              (intern (sly-completing-read
                       "Switch to most recent buffer in what mode? "
                       (mapcar #'symbol-name '(lisp-mode


### PR DESCRIPTION
Was going through and documenting prefix and negative prefix arguments.

`C-u M-x sly-switch-to-most-recent` is documented to prompt for the mode, but actually behaves the same as no prefix argument. This is simply due to an incorrectly named variable.