### PR TITLE
Remove the broken prefix argument for sly-db-eval-in-frame

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -5937,9 +5937,7 @@ The details include local variable bindings and CATCH-tags."
   "Prompt for an expression and evaluate it in the selected frame."
   (interactive (sly-db-frame-eval-interactive "Eval in frame (%s)> "))
   (sly-eval-async `(slynk:eval-string-in-frame ,string ,frame-number ,package)
-    (if current-prefix-arg
-        'sly-write-string
-      'sly-display-eval-result)))
+    'sly-display-eval-result))
 
 (defun sly-db-pprint-eval-in-frame (frame-number string package)
   "Prompt for an expression, evaluate in selected frame, pretty-print result."


### PR DESCRIPTION
If you know what it is actually meant for, then it could be good to fix it instead of removing it. I can't tell what it is actually meant to do though.

Since it tries to run a function that is not defined at all, maybe just remove it as is done here.