### PR TITLE
Document xref functions, and some functions with prefix arguments

### DIFF
--- a/doc/sly.texi
+++ b/doc/sly.texi
@@ -772,9 +772,10 @@ a @code{.lisp} file.
 @section Evaluating code
 
 These commands each evaluate a Common Lisp expression in a different
-way.  Usually they mimic commands for evaluating Emacs Lisp code.  By
+way. Usually they mimic commands for evaluating Emacs Lisp code. By
 default they show their results in the echo area, but a prefix
-argument causes the results to be inserted in the current buffer.
+argument @kbd{C-u} inserts the results into the current buffer, while
+a negative prefix argument @kbd{M--} sends them to the kill ring.
 
 @table @kbd
 
@@ -1441,7 +1442,8 @@ Quit the connection list (kill buffer, restore window configuration).
 Restart the Lisp process for the connection at point.
 
 @cmditem{sly-connect}
-Connect to a running Slynk server.
+Connect to a running Slynk server. With prefix argument, asks if all
+connections should be closed first.
 
 @cmditem{sly-disconnect}
 Disconnect all connections.

--- a/doc/sly.texi
+++ b/doc/sly.texi
@@ -1175,10 +1175,12 @@ Show definition at point in the other window and close
 the @code{*sly-xref} buffer.
 
 @kbditem{C-c C-c, sly-recompile-xref}
-Recompile definition at point.
+Recompile definition at point. Uses prefix arguments like
+@ref{sly-compile-defun}.
 
 @kbditem{C-c C-k, sly-recompile-all-xrefs}
-Recompile all definitions.
+Recompile all definitions. Uses prefix arguments like
+@ref{sly-compile-defun}.
 
 @end table
 

--- a/doc/sly.texi
+++ b/doc/sly.texi
@@ -1000,6 +1000,11 @@ Display the compiler-macro expansion of sexp at point.
 @cmditem{sly-compiler-macroexpand}
 Repeatedly expand compiler macros of sexp at point.
 
+@cmditem{sly-format-string-expand}
+Expand the format-string at point and display it.
+With prefix arg, or if no string at point, prompt the user for a
+string to expand.
+
 @end table
 
 Within a sly macroexpansion buffer some extra commands are provided

--- a/sly.el
+++ b/sly.el
@@ -4917,6 +4917,8 @@ If PROP-VALUE-FN is non-nil use it to extract PROP's value."
           (t (goto-char start) nil))))
 
 (defun sly-recompile-xref (&optional raw-prefix-arg)
+  "Recompile definition at point.
+Uses prefix arguments like `sly-compile-defun'."
   (interactive "P")
   (let ((sly-compilation-policy (sly-compute-policy raw-prefix-arg)))
     (let ((location (sly-xref-location-at-point))
@@ -4927,6 +4929,8 @@ If PROP-VALUE-FN is non-nil use it to extract PROP's value."
                    (list dspec) (current-buffer))))))
 
 (defun sly-recompile-all-xrefs (&optional raw-prefix-arg)
+  "Recompile all definitions.
+Uses prefix arguments like `sly-compile-defun'."
   (interactive "P")
   (let ((sly-compilation-policy (sly-compute-policy raw-prefix-arg)))
     (let ((dspecs) (locations))

--- a/sly.el
+++ b/sly.el
@@ -4140,8 +4140,9 @@ the display stuff that we neither need nor want."
 (defun sly-interactive-eval (string)
   "Read and evaluate STRING and print value in minibuffer.
 
-Note: If a prefix argument is in effect then the result will be
-inserted in the current buffer."
+A prefix argument(`C-u') inserts the result into the current
+buffer. A negative prefix argument (`M--') will sends it to the
+kill ring."
   (interactive (list (sly-read-from-minibuffer "SLY Eval: ")))
   (cl-case current-prefix-arg
     ((nil)


### PR DESCRIPTION
Some functions have undocumented prefix arguments, and the xref commands lack an elisp docstring.