### PR TITLE
Add sly-eval-last-expression-in-context for let* context.

### DIFF
--- a/doc/sly.texi
+++ b/doc/sly.texi
@@ -783,6 +783,10 @@ argument causes the results to be inserted in the current buffer.
 Evaluate the expression before point and show the result in the echo
 area.
 
+@cmditem{sly-eval-last-expression-in-context}
+
+Evaluate a form like `sly-eval-last-expression', but prompt for @code{let*} context variables.
+
 @kbditem{C-M-x, sly-eval-defun}
 Evaluate the current toplevel form and show the result in the echo
 area.  `C-M-x' treats `defvar' expressions specially.  Normally,

--- a/sly.el
+++ b/sly.el
@@ -4233,6 +4233,26 @@ inserted in the current buffer."
   (interactive)
   (sly-interactive-eval (sly-last-expression)))
 
+(defvar-local sly-previous-eval-context nil
+  "The previous evaluation context if any.
+That's set by commands like `sly-eval-last-sexp-in-context'.")
+
+(defun sly-eval-last-expression-in-context ()
+  "Evaluate a form like `sly-eval-last-expression', but prompt for let* context variables.
+Also uses prefix arguments from `sly-interactive-eval'. Here is
+an example interaction:
+(+ x y)| <-- the cursor
+M-x sly-eval-last-expression
+Let context: (x 1) (y 2) RET
+; => 3"
+  (interactive)
+  (let* ((context (sly-read-from-minibuffer "let* context: "
+                                            sly-previous-eval-context))
+         (code (concat "(let* (" context ")"
+                       (sly-last-expression) ")")))
+    (sly-interactive-eval code)
+    (setq-local sly-previous-eval-context context)))
+
 (defun sly-eval-defun ()
   "Evaluate the current toplevel form.
 Use `sly-re-evaluate-defvar' if the from starts with '(defvar'"


### PR DESCRIPTION
TODO:
- Might be more convenient for `let*` context to be like `x 1 y 2` instead of `(x 1) (y 2)`. Clojure's cider uses the first, but Clojure also does its let like this `(let [x 1 y 2] ...)`. I chose the latter option, since it allows for easily using extant CL code and pasting it in.

This kind of interaction is really useful for [REPL driven development](https://vimeo.com/223309989). 