### PR TITLE
Bugfix: sly-mrepl-shortcut displaying partial completions.

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1235,6 +1235,7 @@ When setting this variable outside of the Customize interface,
     ("disconnect all" . sly-disconnect-all)
     ("in-package"     . sly-mrepl-set-package)
     ("restart lisp"   . sly-restart-inferior-lisp)
+    ("quit"           . sly-quit-lisp)
     ("sayoonara"      . sly-quit-lisp)
     ("set directory"  . sly-mrepl-set-directory)
     ("set package"    . sly-mrepl-set-package)))

--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1258,9 +1258,10 @@ When setting this variable outside of the Customize interface,
   (interactive)
   (let* ((string (sly-completing-read "Command: "
                                       (mapcar #'car sly-mrepl-shortcut-alist)
-                                      nil 'require-match nil
-                                      'sly-mrepl-shortcut-history
-                                      (car sly-mrepl-shortcut-history)))
+                                      nil
+                                      t ;require match.
+                                      nil ; do not fill in a completion.
+                                      'sly-mrepl-shortcut-history))
          (command (and string
                        (cdr (assoc string sly-mrepl-shortcut-alist)))))
     (call-interactively command)))

--- a/sly.el
+++ b/sly.el
@@ -828,6 +828,9 @@ move to make TARGET visible."
   (when sly-truncate-lines
     (set (make-local-variable 'truncate-lines) t)))
 
+(defvar sly-read-package-history nil
+  "History for sly-read-package completion. Used by sly-mrepl-shortcut
+in-package.")
 ;; Interface
 (defun sly-read-package-name (prompt &optional initial-value allow-blank)
   "Read a package name from the minibuffer, prompting with PROMPT.
@@ -838,7 +841,9 @@ selected."
                (concat "[sly] " prompt)
                (sly-eval
                 `(slynk:list-all-package-names t))
-               nil (not allow-blank) initial-value)))
+               nil (not allow-blank)
+               initial-value
+               'sly-read-package-history)))
     (unless (zerop (length res))
       res)))
 
@@ -2101,6 +2106,9 @@ Respect `sly-keep-buffers-on-connection-close'."
            (sly-warning "process %s in `sly-net-processes' dead. Force closing..." process)
            (sly-net-close process "process state invalid" nil t)))
 
+(defvar sly-prompt-connection-history nil
+  "History for connection prompt. eg. sayoonara.")
+
 (defun sly-prompt-for-connection (&optional prompt connections dont-require-match)
   (let* ((connections (or connections (sly--purge-connections)))
          (connection-names (cl-loop for process in
@@ -2116,7 +2124,11 @@ Respect `sly-keep-buffers-on-connection-close'."
                                (sly-completing-read
                                 (or prompt "Connection: ")
                                 connection-names
-                                nil (not dont-require-match))))
+                                nil
+                                (not dont-require-match)
+                                (when (null (cdr connection-names));Length of 1.
+                                  (car connection-names))
+                                'sly-prompt-for-connection)))
          (target (cl-find connection-name sly-net-processes :key #'sly-connection-name
                           :test #'string=)))
     (cond (target target)


### PR DESCRIPTION
* contrib/sly-mrepl.el (sly-mrepl-shortcut): Change some variables in this call,
to have better behaviour. With ivy completion, partial entries get
saved and cause annoyance by being selected.

Also, it should require a match, which means using T in that location,
rather than 'require-match (which is a red herring).

So before this bugfix if I did something like this:
```
;;; Use ivy completion.
CL-USER> , ;; call sly-mrepl-shortcut
(minibuffer) Command: in-pa    RET  <--use the ivy completion
                in-package
CL-USER> , ;; call it again
(minibuffer) Command: in-p RET <-- complete with bogus completion "in-pa"
                in-pa
                in-package
ERROR
```
Now it instead pops up with the previous completion pre-filled into the form instead
`Command: in-package`.