### PR TITLE
bugfix: Use history for sly-mrepl-shortcut.

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1258,9 +1258,11 @@ When setting this variable outside of the Customize interface,
   (interactive)
   (let* ((string (sly-completing-read "Command: "
                                       (mapcar #'car sly-mrepl-shortcut-alist)
-                                      nil 'require-match nil
-                                      'sly-mrepl-shortcut-history
-                                      (car sly-mrepl-shortcut-history)))
+                                      nil
+                                      ;; Like T, but RET acts differently.
+                                      'require-match
+                                      nil ; do not fill in a completion.
+                                      'sly-mrepl-shortcut-history))
          (command (and string
                        (cdr (assoc string sly-mrepl-shortcut-alist)))))
     (call-interactively command)))


### PR DESCRIPTION
contrib/sly-mrepl.el Use the symbol that contains the history, rather than the
car of the value of it, which does nothing.

If the point is to have the history be of length one, then that requires doing something else entirely, but I don't think it is as desirable as just using all the history.