### PR TITLE
Bugfix #296: sly-mrepl-shortcut displaying partial completions.

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1259,8 +1259,7 @@ When setting this variable outside of the Customize interface,
   (let* ((string (sly-completing-read "Command: "
                                       (mapcar #'car sly-mrepl-shortcut-alist)
                                       nil 'require-match nil
-                                      'sly-mrepl-shortcut-history
-                                      (car sly-mrepl-shortcut-history)))
+                                      'sly-mrepl-shortcut-history))
          (command (and string
                        (cdr (assoc string sly-mrepl-shortcut-alist)))))
     (call-interactively command)))


### PR DESCRIPTION
Assigning the previous entry as the DEF to completing-read is undesirable. Fixes the abomination that is #296.

This is a bit confusing, so I'll lay it out here:
- Ivy has a bug where `ivy-completing-read` does not accept symbolic values for `require-match`.
- Sly has another bug (fixed here).
[image showing sly history bug](https://spensertruex.com/static/bogus.png)

It is confusing because these two issues were easy to conflate with each other.