### PR TITLE
No required matching to set directory (use current).

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1248,7 +1248,7 @@ When setting this variable outside of the Customize interface,
 (defun sly-mrepl-set-directory ()
   (interactive)
   (let ((directory (read-directory-name "New directory: "
-                                        default-directory nil t)))
+                                        default-directory nil nil)))
     (sly-mrepl--save-and-copy-for-repl
      `(slynk:set-default-directory ,directory)
      :before (format "Setting directory to %s" directory))


### PR DESCRIPTION
* contrib/sly-mrepl.el (sly-mrepl-set-directory): Does not force a match. This
is useful, for example, when selecting an empty directory and having dot files
hidden in the completion framework.

You can turn off dotfiles in `ivy`, but this creates a headache when sly tries to force a match.