### PR TITLE
Document explicitly setting UTF-8 for CLISP

### DIFF
--- a/doc/sly.texi
+++ b/doc/sly.texi
@@ -388,6 +388,13 @@ or @file{~/.emacs.d/init.el} (@pxref{Emacs Init File}).
 (setq inferior-lisp-program "/opt/sbcl/bin/sbcl")
 @end example
 
+If your Common Lisp implementation doesn't automatically turn on UTF-8
+support, you may need to specify it manually:
+
+@example
+(setq inferior-lisp-program "/usr/local/bin/clisp -E UTF-8 -K full")
+@end example
+
 After evaluating this, you should be able to execute @kbd{M-x sly} and
 be greeted with a @REPL{}.
 


### PR DESCRIPTION
Document that implementations like CLISP require you to enable UTF-8 explicitly. If UTF-8 is not explicitly enabled on these implementations, Sly does not work (because UTF-8 is required to spell João Távora's beautiful name)