### PR TITLE
Docs: change sly-apropos-all example to search with regexp

### DIFF
--- a/doc/sly.texi
+++ b/doc/sly.texi
@@ -551,17 +551,15 @@ makes this happen.
 Where should we start though, if we know very little about this project?
 Well, a good point to start is always the @emph{apropos} functionality,
 which is a @code{grep} of sorts, but symbolic rather than purely
-textual.  So if we want to hack on @SLY{}'s ``flex-completion'', so we
-type @kbd{C-c C-d C-z} (the shortcut for @kbd{M-x sly-apropos-all}) and
-then type in ``slyflex'' at the prompt, followed by @kbd{enter}
-or @kbd{return} (abbreviated @code{RET} or @kbd{C-m}).
+textual. In order to enable regular expression search with sly-apropos,
+we first need to load CL-PPCRE. You can do this from the @REPL{} with
+Quicklisp's @code{(ql:quickload :cl-ppcre)}.
 
-Notice that we’ve just entered a @emph{fuzzy} or @emph{flex} search
-string in @SLY{}'s @emph{apropos} prompt, something that a regular
-Lisp @emph{apropos} search doesn’t allow.  You could also have searched
-by regular expression (see the @code{*PREFERRED-APROPOS-MATCHER*}
-variable).  Anyway, @SLY{} should now present all Lisp symbols matching
-your search pattern, with the better matches sorted at the top.
+So if we want to hack on @SLY{}'s ``flex-completion'', we type
+@kbd{C-c C-d C-z} (the shortcut for @kbd{M-x sly-apropos-all}) and
+then type in ``sly.*flex'' at the prompt, followed by @kbd{enter}
+or @kbd{return} (abbreviated @code{RET} or @kbd{C-m}). @SLY{} should
+now present all Lisp symbols matching your search pattern.
 
 @*@image{images/tutorial-2,350pt}@*
 


### PR DESCRIPTION
Hi! I finally got some time to get back to SLY and docs. I did my best to try and match the docs for `sly-apropos-all` to the situation as I understand it.  I'm not sure if its appropriate to mention Quicklisp in the docs for loading CL-PPCRE to get regexp search or not, and I'm afraid I'm not experienced enough to know how to fix the flex search. It is interesting though :)

One (small) benefit of this change is it makes the associated image for the apropos search match the documentation again. Happy to make any edits if you have suggestions.

addresses #314 