### PR TITLE
Remove unnecessary macros

### DIFF
--- a/slynk/slynk.lisp
+++ b/slynk/slynk.lisp
@@ -479,8 +479,11 @@ corresponding values in the CDR of VALUE."
 
 ;;; Channels
 
-(defmacro channels () `(connection-channels *emacs-connection*))
-(defmacro channel-counter () `(connection-channel-counter *emacs-connection*))
+(defun channels () (connection-channels *emacs-connection*))
+(defun (setf channels) (value) (setf (connection-channels *emacs-connection*) value))
+
+(defun channel-counter () (connection-channel-counter *emacs-connection*))
+(defun (setf channels) (value) (setf (connection-channel-counter *emacs-connection*) value))
 
 (defclass channel ()
   ((id     :initform (incf (channel-counter))

--- a/slynk/slynk.lisp
+++ b/slynk/slynk.lisp
@@ -483,7 +483,7 @@ corresponding values in the CDR of VALUE."
 (defun (setf channels) (value) (setf (connection-channels *emacs-connection*) value))
 
 (defun channel-counter () (connection-channel-counter *emacs-connection*))
-(defun (setf channels) (value) (setf (connection-channel-counter *emacs-connection*) value))
+(defun (setf channel-counter) (value) (setf (connection-channel-counter *emacs-connection*) value))
 
 (defclass channel ()
   ((id     :initform (incf (channel-counter))


### PR DESCRIPTION
Generally better style and makes calling into slynk functionality simpler when writing slynk-optional code (eg code that calls into slynk iff slynk is available)