### PR TITLE
sly-db-setup: don't assume there are more frames to show

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -5519,7 +5519,9 @@ pending Emacs continuations."
           (setq sly-db-backtrace-start-marker (point-marker))
           (save-excursion
             (if frame-specs
-                (sly-db-insert-frames (sly-db-prune-initial-frames frame-specs) t)
+                (let* ((initial-frames (sly-db-prune-initial-frames frame-specs))
+                       (more (sly-length> frame-specs (length initial-frames))))
+                  (sly-db-insert-frames initial-frames more))
               (insert "[No backtrace]")))
           (run-hooks 'sly-db-hook)
           (set-syntax-table lisp-mode-syntax-table)))


### PR DESCRIPTION
Check to see if there are actually more frames to show before calling `sly-db-insert-frames` (instead of always passing `t` as the second argument to `sly-db-insert-frames`).  The number of frames given to `sly-db-setup` could be the same as the number of frames returned by `sly-db-prune-initial-frames`.

This prevents `--more--` from being shown when there aren't actually any more frames.

I stumbled across this in SLIME by invoking the debugger from the `*inferior-lisp*` buffer.  SLY has been behaving the same way.

This goes along with my SLIME PR: https://github.com/slime/slime/pull/569