### PR TITLE
Revert "Fix #330: only insert "--more--" button in SLY DB when actually needed"

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -5523,9 +5523,7 @@ pending Emacs continuations."
           (setq sly-db-backtrace-start-marker (point-marker))
           (save-excursion
             (if frame-specs
-                (let* ((initial-frames (sly-db-prune-initial-frames frame-specs))
-                       (more (sly-length> frame-specs (length initial-frames))))
-                  (sly-db-insert-frames initial-frames more))
+                (sly-db-insert-frames (sly-db-prune-initial-frames frame-specs) t)
               (insert "[No backtrace]")))
           (run-hooks 'sly-db-hook)
           (set-syntax-table lisp-mode-syntax-table)))


### PR DESCRIPTION
Reverts #330 

Unfortunately my proposed fix for #330 was a bit too simplistic and a proper fix will be a little more involved than just the comparison I proposed (see slime/slime#571).