### PR TITLE
Fix #336: when `last-command' is not a symbol

### DIFF
--- a/lib/sly-buttons.el
+++ b/lib/sly-buttons.el
@@ -275,7 +275,8 @@ at exactly the same spot, they are both visited simultaneously,
 `sly-button-echo' being passed a variable number of button arguments."
   (cl-loop for i from 0 below (abs n)
            for buttons =
-           (or (and (not (get last-command 'sly-button-navigation-command))
+           (or (and (or (not (symbolp last-command))
+                        (not (get last-command 'sly-button-navigation-command)))
                     (sly-button--searchable-buttons-starting-at (point) filter))
                (sly-button--search-1 n filter))
            for button = (car buttons)


### PR DESCRIPTION
* lib/sly-buttons.el (sly-button-search): add a `symbolp' conditional.