### PR TITLE
Escaping for backreference messages.

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1384,7 +1384,7 @@ a list of result buttons thus highlighted"
          (t
           (overlay-put overlay 'face 'font-lock-warning-face)
           (setq message-text (format "Invalid backreference `%s'" m0))))
-        (sly-message message-text)
+        (sly-message "%s" message-text)
         (set (make-local-variable 'sly-autodoc-preamble) message-text)))))
 
 


### PR DESCRIPTION
Backreference messages sometimes contain "%" symbols, and would cause
`sly-mrepl--highlight-backreferences-maybe' to throw an error. This is a simple fix to escape the message.