### PR TITLE
add safe check for package guess.

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1025,15 +1025,16 @@ handle to distinguish the new buffer from the existing."
   (interactive (list (point) t))
   (let* ((point (or point (point)))
          (probe
-           (previous-single-property-change point
-                                            'sly-mrepl--prompt))
+          (previous-single-property-change point
+                                           'sly-mrepl--prompt))
          (package (and probe
                        (or (get-text-property probe 'sly-mrepl--prompt)
-                           (and (previous-single-property-change
-                                 probe 'sly-mrepl--prompt)
-                                (get-text-property (previous-single-property-change
-                                                    probe 'sly-mrepl--prompt)
-                                                   'sly-mrepl--prompt))))))
+                           (let ((probe2
+                                  (previous-single-property-change
+                                   probe 'sly-mrepl--prompt)))
+                             (and probe2
+                                  (get-text-property probe2
+                                                     'sly-mrepl--prompt)))))))
     (when interactive
       (sly-message "Guessed package \"%s\"" package))
     package))

--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1025,13 +1025,15 @@ handle to distinguish the new buffer from the existing."
   (interactive (list (point) t))
   (let* ((point (or point (point)))
          (probe
-          (previous-single-property-change point
-                                           'sly-mrepl--prompt))
+           (previous-single-property-change point
+                                            'sly-mrepl--prompt))
          (package (and probe
                        (or (get-text-property probe 'sly-mrepl--prompt)
-                           (get-text-property (previous-single-property-change
-                                               probe 'sly-mrepl--prompt)
-                                              'sly-mrepl--prompt)))))
+                           (and (previous-single-property-change
+                                 probe 'sly-mrepl--prompt)
+                                (get-text-property (previous-single-property-change
+                                                    probe 'sly-mrepl--prompt)
+                                                   'sly-mrepl--prompt))))))
     (when interactive
       (sly-message "Guessed package \"%s\"" package))
     package))


### PR DESCRIPTION
I edit lisp codes in org file with https://github.com/polymode/poly-org, sometimes `previous-single-property-change` will return nil value when guess package.