### PR TITLE
Make prompt customizable

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -414,6 +414,13 @@ In that case, moving a sexp backward does nothing."
            ;; If no process yet, fall back to the simpler strategy.
            (sly-mrepl--insert-output string face)))))
 
+(defun sly-mrepl--remove-comint-highlight (start end)
+  "Some `comint' functions force the `comint-highlight-prompt'
+face, which we don't want so we remove it."
+  (font-lock--remove-face-from-text-property
+   start end
+   'font-lock-face 'comint-highlight-prompt))
+
 (defun sly-mrepl--send-input-sexp ()
   (goto-char (point-max))
   (save-excursion
@@ -424,15 +431,18 @@ In that case, moving a sexp backward does nothing."
   (buffer-disable-undo)
   (overlay-put sly-mrepl--last-prompt-overlay 'face 'highlight)
   (set (make-local-variable 'sly-mrepl--dirty-history) t)
-  (sly-mrepl--commiting-text
-      `(field sly-mrepl-input
-              keymap ,(let ((map (make-sparse-keymap)))
-                        (define-key map (kbd "RET") 'sly-mrepl-insert-input)
-                        (define-key map [return] 'sly-mrepl-insert-input)
-                        (define-key map [mouse-2] 'sly-mrepl-insert-input)
-                        map))
-    (comint-send-input))
-  (sly-mrepl--ensure-prompt-face))
+  (let ((previous-comint-last-prompt comint-last-prompt))
+    (sly-mrepl--commiting-text
+        `(field sly-mrepl-input
+                keymap ,(let ((map (make-sparse-keymap)))
+                          (define-key map (kbd "RET") 'sly-mrepl-insert-input)
+                          (define-key map [return] 'sly-mrepl-insert-input)
+                          (define-key map [mouse-2] 'sly-mrepl-insert-input)
+                          map))
+      (prog1 (comint-send-input)
+        (sly-mrepl--remove-comint-highlight
+         (car previous-comint-last-prompt)
+         (cdr previous-comint-last-prompt))))))
 
 (defun sly-mrepl--ensure-newline ()
   (unless (save-excursion
@@ -450,13 +460,6 @@ In that case, moving a sexp backward does nothing."
     (while (accept-process-output sly-mrepl--dedicated-stream
                                   0
                                   (and (eq (window-system) 'w32) 1)))))
-
-(defun sly-mrepl--ensure-prompt-face ()
-  "Override `comint.el''s use of `comint-highlight-prompt'."
-  (let ((inhibit-read-only t))
-    (add-text-properties (overlay-start sly-mrepl--last-prompt-overlay)
-                         (overlay-end sly-mrepl--last-prompt-overlay)
-                         '(font-lock-face sly-mrepl-prompt-face))))
 
 (cl-defun sly-mrepl-format-default-prompt (_package
                                            package-nickname
@@ -513,8 +516,12 @@ Return a possibly propertized string."
                :error-level error-level
                :condition condition)
       'sly-mrepl--prompt (downcase package)))
+      ;; `comint-output-filter' forces the `comint-highlight-prompt' face, which
+      ;; we don't want, so we remove it here.
+    (let ((prompt-start (save-excursion (forward-line 0) (point)))
+          (inhibit-read-only t))
+      (sly-mrepl--remove-comint-highlight prompt-start (point)))
     (move-overlay sly-mrepl--last-prompt-overlay beg (sly-mrepl--mark)))
-  (sly-mrepl--ensure-prompt-face)
   (buffer-disable-undo)
   (buffer-enable-undo))
 

--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -462,7 +462,6 @@ In that case, moving a sexp backward does nothing."
                                            package-nickname
                                            &key
                                            error-level
-                                           _condition
                                            &allow-other-keys)
   "Return the default SLY prompt string.
 Suitable for `sly-mrepl-prompt-formatter'."
@@ -484,6 +483,7 @@ It takes the following arguments:
 - PACKAGE: The full name of the current package as a string.
 - PACKAGE-NICKNAME: The nickname of the current package as a string, not
   necessarily the same as PACKAGE.
+- ENTRY-IDX (key argument): Entry index as a fixnum.
 - ERROR-LEVEL (key argument): Number of oustanding errors as a fixnum.
 - CONDITION (key argument): The Common Lisp condition.
 
@@ -498,10 +498,16 @@ Return a possibly propertized string."
     (sly-mrepl--insert-note (format "Debugger entered on %s" condition)))
   (sly-mrepl--ensure-newline)
   (sly-mrepl--catch-up)
-  (let ((beg (marker-position (sly-mrepl--mark))))
+  (let ((beg (marker-position (sly-mrepl--mark)))
+        (last-button (previous-button (point))))
     (sly-mrepl--insert
      (propertize
-      (funcall sly-mrepl-prompt-formatter package-nickname
+      (funcall sly-mrepl-prompt-formatter
+               package
+               package-nickname
+               :entry-idx (or (when last-button
+                                (1+ (car (button-get (previous-button (point)) 'part-args))))
+                              0)
                :error-level error-level
                :condition condition)
       'sly-mrepl--prompt (downcase package)))

--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -505,8 +505,10 @@ Return a possibly propertized string."
       (funcall sly-mrepl-prompt-formatter
                package
                package-nickname
-               :entry-idx (or (when last-button
-                                (1+ (car (button-get (previous-button (point)) 'part-args))))
+               :entry-idx (or (when (and last-button
+                                         (button-type-subtype-p (button-type last-button)
+                                                                'sly-mrepl-part))
+                                (1+ (car (button-get last-button 'part-args))))
                               0)
                :error-level error-level
                :condition condition)

--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -474,7 +474,8 @@ Suitable for `sly-mrepl-prompt-formatter'."
 
 (defcustom sly-mrepl-prompt-formatter #'sly-mrepl--format-default-prompt
   "Function called when preparing the prompt.
-It takes the current Common Lisp package and the error-level (possibly nil).
+Takes two arguments, a string designating the current Common Lisp package and a
+fixnum indicating how many errors are outstanding.  The error level may be nil.
 Return a possibly propertized string."
   :type 'function
   :group 'sly)


### PR DESCRIPTION
Closes #360.

* contrib/sly-mrepl.el (sly-mrepl-prompt-formatter): New defcustom.
(sly-mrepl-format-default-prompt): New function.
(sly-mrepl--insert-prompt): Call sly-mrepl-prompt-formatter.