### PR TITLE
Fix sly change directory

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1286,6 +1286,11 @@ Return whatever `sly-change-directory' returns."
      :before (format "Setting directory to %s" directory))
     (cd directory)))
 
+(defun sly-cd (directory)
+  "Alias for `sly-mrepl-set-directory'."
+  (interactive (list (read-directory-name "[sly] Directory: " nil nil t)))
+  (sly-mrepl-set-directory directory))
+
 (defun sly-mrepl-shortcut ()
   (interactive)
   (let* ((string (sly-completing-read "Command: "

--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1274,10 +1274,13 @@ When setting this variable outside of the Customize interface,
   (let ((package (sly-read-package-name "New package: ")))
     (sly-mrepl--eval-for-repl `(slynk-mrepl:guess-and-set-package ,package))))
 
-(defun sly-mrepl-set-directory ()
+(defun sly-mrepl-set-directory (&optional directory)
+  "Make DIRECTORY (or prompt for it if nil) become the Lisp's current directory.
+Also switch directory in the current REPL.
+Return whatever `sly-change-directory' returns."
   (interactive)
-  (let ((directory (read-directory-name "New directory: "
-                                        default-directory nil t)))
+  (let ((directory (or directory (read-directory-name "New directory: "
+                                                      default-directory nil t))))
     (sly-mrepl--save-and-copy-for-repl
      `(slynk:set-default-directory ,directory)
      :before (format "Setting directory to %s" directory))

--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1281,10 +1281,13 @@ Return whatever `sly-change-directory' returns."
   (interactive)
   (let ((directory (or directory (read-directory-name "New directory: "
                                                       default-directory nil t))))
-    (sly-mrepl--save-and-copy-for-repl
-     `(slynk:set-default-directory ,directory)
-     :before (format "Setting directory to %s" directory))
-    (cd directory)))
+    (prog1 (sly-change-directory
+            directory
+            (lambda (body)
+              (sly-mrepl--save-and-copy-for-repl
+               body
+               :before (format "Setting directory to %s" directory))))
+      (cd directory))))
 
 (defun sly-cd (directory)
   "Alias for `sly-mrepl-set-directory'."

--- a/sly.el
+++ b/sly.el
@@ -4418,12 +4418,6 @@ Return whatever slynk:set-default-directory returns."
       (sly-with-connection-buffer nil (cd-absolute dir))
       (run-hook-with-args 'sly-change-directory-hooks dir))))
 
-(defun sly-cd (directory)
-  "Make DIRECTORY become Lisp's current directory.
-Return whatever slynk:set-default-directory returns."
-  (interactive (list (read-directory-name "[sly] Directory: " nil nil t)))
-  (sly-message "default-directory: %s" (sly-change-directory directory)))
-
 (defun sly-pwd ()
   "Show Lisp's default directory."
   (interactive)

--- a/sly.el
+++ b/sly.el
@@ -4412,7 +4412,8 @@ The functions are called with the new (absolute) directory.")
 Return whatever slynk:set-default-directory returns."
   (let ((dir (expand-file-name directory)))
     (prog1 (sly-eval `(slynk:set-default-directory
-                       ,(sly-to-lisp-filename dir)))
+                       (slynk-backend:filename-to-pathname
+                        ,(sly-to-lisp-filename dir))))
       (sly-with-connection-buffer nil (cd-absolute dir))
       (run-hook-with-args 'sly-change-directory-hooks dir))))
 

--- a/sly.el
+++ b/sly.el
@@ -4407,13 +4407,14 @@ in Lisp when committed with \\[sly-edit-value-commit]."
   "Hook run by `sly-change-directory'.
 The functions are called with the new (absolute) directory.")
 
-(defun sly-change-directory (directory)
+(defun sly-change-directory (directory &optional evaluator)
   "Make DIRECTORY become Lisp's current directory.
 Return whatever slynk:set-default-directory returns."
   (let ((dir (expand-file-name directory)))
-    (prog1 (sly-eval `(slynk:set-default-directory
-                       (slynk-backend:filename-to-pathname
-                        ,(sly-to-lisp-filename dir))))
+    (prog1 (funcall (or evaluator 'sly-eval)
+                    `(slynk:set-default-directory
+                      (slynk-backend:filename-to-pathname
+                       ,(sly-to-lisp-filename dir))))
       (sly-with-connection-buffer nil (cd-absolute dir))
       (run-hook-with-args 'sly-change-directory-hooks dir))))
 


### PR DESCRIPTION
A few "cd"-related issues here.

Changing directory should happen both in the Lisp image and in the various mREPLs connected to that image.

I don't think it's OK to call mrepl code in sly.el, so `sly-change-directory` is probably not right as I've patched it.

Maybe move sly-change-directory to contrib/sly-mrepl?