### PR TITLE
Handle special characters when setting directory.

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -1279,7 +1279,9 @@ When setting this variable outside of the Customize interface,
   (let ((directory (read-directory-name "New directory: "
                                         default-directory nil t)))
     (sly-mrepl--save-and-copy-for-repl
-     `(slynk:set-default-directory ,directory)
+     `(slynk:set-default-directory
+       (slynk-backend:filename-to-pathname
+        ,directory))
      :before (format "Setting directory to %s" directory))
     (cd directory)))
 

--- a/sly.el
+++ b/sly.el
@@ -4412,7 +4412,8 @@ The functions are called with the new (absolute) directory.")
 Return whatever slynk:set-default-directory returns."
   (let ((dir (expand-file-name directory)))
     (prog1 (sly-eval `(slynk:set-default-directory
-                       ,(sly-to-lisp-filename dir)))
+                       (slynk-backend:filename-to-pathname
+                        ,(sly-to-lisp-filename dir))))
       (sly-with-connection-buffer nil (cd-absolute dir))
       (run-hook-with-args 'sly-change-directory-hooks dir))))
 


### PR DESCRIPTION
* sly.el (sly-change-directory): Wrap directory with
slynk-backend:filename-to-pathname.
* contrib/sly-mrepl.el (sly-mrepl-set-directory): Same.