### PR TITLE
mention lisp-repl-core-dumper for instant SLY startup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ $ sbcl
 Now in Emacs you can do `sly-connect` and give it the host and the 4008 port as
 a destination.
 
+Instant REPL startup
+--------------------
+
+To dramatically increase the startup time of the REPL, [Lisp REPL core
+dumper](https://gitlab.com/ambrevar/lisp-repl-core-dumper) can generate
+preloaded executable images on demand.  See the official website for the Emacs
+setup.
+
 Additional Contribs
 -------------------
 

--- a/doc/sly.texi
+++ b/doc/sly.texi
@@ -2929,6 +2929,11 @@ shell$ sbcl
 * (slynk-loader:dump-image "sbcl.core-with-slynk")
 @end example
 
+The above steps have the drawback that they must be repeated when the
+Lisp compiler is updated, and for each compiler.
+See @url{https://gitlab.com/ambrevar/lisp-repl-core-dumper} for an
+automated, portable way to generate fast-starting images.
+
 @noindent
 Then add this to the Emacs initializion file:
 


### PR DESCRIPTION
* README.md (Instant REPL startup): New section.

* doc/sly.texi (Loading Slynk faster): Mention lisp-repl-code-dumper.