### PR TITLE
flex-completion: tweak scores to favor accessible symbols and matches near dashes

### DIFF
--- a/slynk/slynk-completion.lisp
+++ b/slynk/slynk-completion.lisp
@@ -201,7 +201,12 @@ INDEXES as calculated by FLEX-MATCHES."
           (t
            ;; the default: score the whole pattern on the whole
            ;; string.
-           (flex-score-1 string-length indexes)))))
+           (let ((dashes (loop
+                           for i in indexes
+                           count (or (= i 0) (char= #\- (char string (1- i)))))))
+             (+ (flex-score-1 string-length indexes)
+                (* dashes 0.5)
+                (if (find #\: string) 0 1.0)))))))
 
 (defun flex-score-1 (string-length indexes)
   "Does the real work of FLEX-SCORE.


### PR DESCRIPTION
Hi,

This patch is small but probably more like a hack, I submit it as a pull-request to start a discussion about the feature. The intent was to have "mvb" expand as "multiple-value-bind" in priority, because otherwise I have this list of results with a lot of symbols I never use and IMO should not show first if there is no colon in the query:

```
(("sb-c:movable" 0.027211923 ((5 "M") (7 "V") (9 "B")) "")
  ("fare-utils:mvbind" 0.011965677 ((11 "MVB")) "macro")
  ("*compile-verbose*" 0.006256731 ((3 "M") (9 "V") (12 "B")) "var")
  ("cl:*compile-verbose*" 0.0046182764 ((6 "M") (12 "V") (15 "B")) "var")
  ("c2cl:*compile-verbose*" 0.003978178 ((8 "M") (14 "V") (17 "B")) "var")
  ("multiple-value-bind" 0.003946983 ((0 "M") (9 "V") (15 "B")) "macro")
  ("common-lisp:variable" 0.003600848 ((2 "M") (12 "V") (17 "B")) "")
  ("ql-cmucl:*gc-verbose*" 0.0033648403 ((4 "M") (13 "V") (16 "B")) "fn")
  ("cl:multiple-value-bind" 0.0033352638 ((3 "M") (12 "V") (18 "B")) "macro")
  ("sb-vm:primitive-object" 0.0030422306 ((4 "M") (13 "V") (17 "B")) "cla")
  ("c2cl:multiple-value-bind" 0.0030168907 ((5 "M") (14 "V") (20 "B"))
   "macro"))
```

The patch adds the following heuristics:

1. if the search string does not have colons, bump the score for unqualified strings
2. count how many indices in the match are at beginning of string or just after a dash (like "m", "v" and "b"), to favor search queries that align with words

Thank you.