### PR TITLE
2021-06-13  alejandrozf  <allejjandrozf@gmail.com>

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -2707,7 +2707,7 @@ Debugged requests are ignored."
 ;;;;; Event logging to *sly-events*
 ;;;
 ;;; The *sly-events* buffer logs all protocol messages for debugging
-;;; purposes. 
+;;; purposes.
 
 (defvar sly-log-events t
   "*Log protocol events to the *sly-events* buffer.")
@@ -6670,6 +6670,17 @@ If PREV resp. NEXT are true insert more-buttons as needed."
     (when (and next (< end len))
       (sly-inspector-insert-more-button end nil))))
 
+
+(defun sly-interactive-eval-setf (var-name prompt-user)
+  (call-interactively
+   (lambda (string)
+     (interactive (list (sly-read-from-minibuffer
+                         (or prompt-user "SLY Eval: "))))
+     (sly-eval-with-transcript `(slynk:interactive-eval
+                                 ,(format "(setf %s %s)"
+                                          (or var-name (gensym "inspector")) string))))))
+
+
 (defun sly-inspector-insert-ispec (ispec)
   (insert
    (if (stringp ispec) ispec
@@ -6682,8 +6693,13 @@ If PREV resp. NEXT are true insert more-buttons as needed."
         (sly-make-action-button
          string
          #'(lambda (_button)
+             (when (string= string "[add entry hashtable]")
+               (sly-interactive-eval-setf "slynk:*inspector-ht-key*" "Insert key: ") ;set key
+               (sly-interactive-eval-setf "slynk:*inspector-ht-value*" "Insert value: ") ;set value
+               )
              (sly-eval-for-inspector `(slynk::inspector-call-nth-action ,id)
                                      :restore-point t))))))))
+
 
 (defun sly-inspector-position ()
   "Return a pair (Y-POSITION X-POSITION) representing the

--- a/slynk/slynk.lisp
+++ b/slynk/slynk.lisp
@@ -74,7 +74,11 @@
            #:*find-definitions-left-trim*
            #:*after-toggle-trace-hook*
            #:*echo-number-alist*
-           #:*present-number-alist*))
+           #:*present-number-alist*
+           ;; used by inspector action buttons
+           #:*inspector-ht-key*
+           #:*inspector-ht-value*
+           ))
 
 (in-package :slynk)
 
@@ -123,6 +127,14 @@
   "An alist to initialize dynamic variables in worker threads.
 The list has the form ((VAR . VALUE) ...).  Each variable VAR will be
 bound to the corresponding VALUE.")
+
+(defvar *inspector-ht-key* nil
+  "The value entered interactively to set the key part for a hashtable
+from inspector")
+
+(defvar *inspector-ht-value* nil
+  "The value entered interactively to set the valyue part for a hashtable
+from inspector")
 
 (defun call-with-bindings (alist fun)
   "Call FUN with variables bound according to ALIST.
@@ -200,18 +212,18 @@ Backend code should treat the connection structure as opaque.")
 ;;;; Connections
 ;;;
 ;;; Connection structures represent the network connections between
-;;; Emacs and Lisp. 
+;;; Emacs and Lisp.
 ;;;
 (defstruct (connection
              (:constructor %make-connection)
              (:conc-name connection-)
              (:print-function print-connection))
   ;; The listening socket. (usually closed)
-  ;; 
+  ;;
   (socket           (missing-arg) :type t :read-only t)
   ;; Character I/O stream of socket connection.  Read-only to avoid
   ;; race conditions during initialization.
-  ;; 
+  ;;
   (socket-io        (missing-arg) :type stream :read-only t)
   ;; An alist of (ID . CHANNEL) entries. Channels are good for
   ;; streaming data over the wire (see their description in sly.el)
@@ -225,19 +237,19 @@ Backend code should treat the connection structure as opaque.")
   ;; A list of INSPECTOR objects. Each inspector has its own history
   ;; of inspected objects. An inspector might also be tied to a
   ;; specific thread.
-  ;; 
+  ;;
   (inspectors '() :type list)
   ;;Cache of macro-indentation information that
   ;; has been sent to Emacs.  This is used for preparing deltas to
   ;; update Emacs's knowledge.  Maps: symbol ->
   ;; indentation-specification
-  ;; 
+  ;;
   (indentation-cache (make-hash-table :test 'eq) :type hash-table)
   ;; The list of packages represented in the cache:
-  ;; 
+  ;;
   (indentation-cache-packages '())
   ;; The communication style used.
-  ;; 
+  ;;
   (communication-style nil :type (member nil :spawn :sigio :fd-handler))
   )
 
@@ -551,7 +563,7 @@ corresponding values in the CDR of VALUE."
 
 (defmacro listeners () `(connection-listeners *emacs-connection*))
 
-(defmethod initialize-instance :after ((l listener) &key initial-env) 
+(defmethod initialize-instance :after ((l listener) &key initial-env)
   (with-slots (out in env) l
     (let ((io (make-two-way-stream in out)))
       (setf env
@@ -1302,12 +1314,12 @@ point the thread terminates and CHANNEL is closed."
        (cond ((and ch thread)
               (send-event thread `(:emacs-channel-send ,ch ,msg)))
              (ch
-              (encode-message 
+              (encode-message
                (list :invalid-channel channel-id
                      "No suitable threads for channel")
                (current-socket-io)))
              (t
-              (encode-message 
+              (encode-message
                (list :invalid-channel channel-id "Channel not found")
                (current-socket-io))))))
     ((:reader-error packet condition)
@@ -1978,7 +1990,7 @@ invoke our debugger.  EXTRA-REX-OPTIONS are passed to the functions of
                                      ;; (setq result (apply (car form) (cdr form)))
                                      (eval form)))
                               ;; Honour *EVAL-FOR-EMACS-WRAPPERS*
-                              ;; 
+                              ;;
                               (loop for lambda = #'eval-it then
                                                            (handler-case
                                                                (apply wrapper lambda extra-rex-options)
@@ -2278,7 +2290,7 @@ MAP -- rewrite the chars in STRING according to this alist."
 (defvar *canonical-package-nicknames*
   `((:common-lisp-user . :cl-user))
   "Canonical package names to use instead of shortest name/nickname.")
-  
+
 (defvar *auto-abbreviate-dotted-packages* t
   "Abbreviate dotted package names to their last component if T.")
 
@@ -2552,7 +2564,7 @@ conditions are simply reported."
   ;; JT@15/08/24: FIXME: Actually, with a nice and proper method-combination for
   ;; interfaces (as was once quite bravely attempted by Helmut, this variable
   ;; could go away and contribs could simply add methods to CONDITION-EXTRAS)
-  ;; 
+  ;;
   "A property list of extra options describing a condition.
 This works much like the CONDITION-EXTRAS interface, but can be
 dynamically bound by contribs when invoking the debugger.")
@@ -3392,7 +3404,7 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
    (name :initarg :name :initform (error "Name this INSPECTOR!") :accessor inspector-name)))
 
 (defmethod print-object ((i inspector) s)
-  (print-unreadable-object (i s :type t) 
+  (print-unreadable-object (i s :type t)
     (format s "~a/~a" (inspector-name i) (length (inspector-%history i)))))
 
 (defmethod initialize-instance :after ((i inspector) &key name)
@@ -3717,6 +3729,9 @@ Return NIL if LIST is circular."
    (let ((weakness (hash-table-weakness ht)))
      (when weakness
        (label-value-line "Weakness:" weakness)))
+   `((:action "[add entry hashtable]"
+              ,(lambda () (setf (gethash *inspector-ht-key* ht)
+                                *inspector-ht-value*))) (:newline))
    (unless (zerop (hash-table-count ht))
      `((:action "[clear hashtable]"
                 ,(lambda () (clrhash ht))) (:newline)
@@ -3793,7 +3808,7 @@ Example:
   (when (and *emacs-connection*
              (use-threads-p)
              ;; FIXME: hardcoded thread name
-             (equalp (thread-name (current-thread)) "slynk-worker")) 
+             (equalp (thread-name (current-thread)) "slynk-worker"))
     (setf *thread-list* (delete (current-thread) *thread-list*)))
   (let* ((plist (thread-attributes (car *thread-list*)))
          (labels (loop for (key) on plist by #'cddr


### PR DESCRIPTION
    New feature proposed:
    
    - Added new button inside inspector for hash tables, that allows to interactively set a key value (tested on SBCL and CCL but should work for other Lisp implementations)

    * sly.el (sly-inspector-insert-ispec):

    * slynk/slynk.lisp (emacs-inspect):