### PR TITLE
Fix nil find-tag-marker-ring in sly-edit-uses

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -3910,7 +3910,9 @@ For insertion in the `compilation-mode' buffer"
 
 (defun sly-push-definition-stack ()
   "Add point to find-tag-marker-ring."
-  (ring-insert find-tag-marker-ring (point-marker)))
+  (if (version< emacs-version "25.1")
+      (ring-insert find-tag-marker-ring (point-marker))
+    (xref-push-marker-stack (point-marker))))
 
 (defun sly-pop-find-definition-stack ()
   "Pop the edit-definition stack and goto the location."


### PR DESCRIPTION
On newer versions of Emacs, find-tag-marker-ring has been removed.
To push a marker, one should use xref-push-marker-stack instead.