### PR TITLE
Use xref-push-marker-stack when available

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -3910,7 +3910,10 @@ For insertion in the `compilation-mode' buffer"
 
 (defun sly-push-definition-stack ()
   "Add point to find-tag-marker-ring."
-  (ring-insert find-tag-marker-ring (point-marker)))
+  (require 'etags)
+  (if (fboundp 'xref-push-marker-stack)
+      (xref-push-marker-stack)
+    (ring-insert find-tag-marker-ring (point-marker))))
 
 (defun sly-pop-find-definition-stack ()
   "Pop the edit-definition stack and goto the location."


### PR DESCRIPTION
* sly.el (sly-push-definition-stack): Inserting directly into
`find-tag-marker-ring` is obsolete since emacs 25.1.  As of emacs 29 sly no
longer is able to jump back and forth between definition and usage with `M-.`
and `M-,`.  As a precaution for backwards compatibility, we use
`xref-push-marker-stack` only when it is bound.