### PR TITLE
Allow READ-FROM-MINIBUFFER-IN-EMACS to return an empty string

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -4152,7 +4152,7 @@ the display stuff that we neither need nor want."
 
 (defun sly-read-from-minibuffer-for-slynk (thread tag prompt initial-value)
   (let ((answer (condition-case nil
-                    (sly-read-from-minibuffer prompt initial-value t)
+                    (sly-read-from-minibuffer prompt initial-value t t)
                   (quit nil))))
     (sly-dispatch-event `(:emacs-return ,thread ,tag ,answer))))
 


### PR DESCRIPTION
The docstring for READ-FROM-MINIBUFFER-IN-EMACS says that an empty string is
returned when a user enters nothing. Prior to this commit,
SLY-READ-FROM-MINIBUFFER was called in such a way that an empty result wasn't
allowed.