### PR TITLE
fix definition-source-for-emacs for case when source was categorized as :file-without-position

### DIFF
--- a/slynk/backend/sbcl.lisp
+++ b/slynk/backend/sbcl.lisp
@@ -1003,7 +1003,9 @@ QUALITIES is an alist with (quality . value)"
                       '(:position 1)
                       (when (eql type :function)
                         `(:snippet ,(format nil "(defun ~a "
-                                            (symbol-name name))))))
+                                            (etypecase name
+                                              (symbol (symbol-name name))
+                                              (string name)))))))
       (:invalid
        (error "DEFINITION-SOURCE of ~(~A~) ~A did not contain ~
                meaningful information."


### PR DESCRIPTION
This fix relates to SBCL and the case when definition relates to a function.

Here definition-source-for-emacs is called with name having string type:
https://github.com/joaotavora/sly/blob/b501b4335096fd4306c2c1eb86382b69e91c09e5/slynk/backend/sbcl.lisp#L872

In this case we have to use it as is instead of trying to call SYMBOL-NAME.

I've encounter this problem when attempted to setup logical pathname translations
to make SLY open local files when connected to the remote Lisp image.

Here is the Reddit discussion where everything begins:
https://www.reddit.com/r/Common_Lisp/comments/vc6hix/source_location_for_deployed_binary/