### PR TITLE
clasp: Update for changes in logical hosts and some function names

### DIFF
--- a/slynk/backend/clasp.lisp
+++ b/slynk/backend/clasp.lisp
@@ -64,7 +64,11 @@
 			       :type :stream
 			       :protocol :tcp)))
     (setf (sb-bsd-sockets:sockopt-reuse-address socket) t)
-    (sb-bsd-sockets:socket-bind socket (resolve-hostname host) port)
+    (handler-bind
+        ((SB-BSD-SOCKETS:ADDRESS-IN-USE-ERROR (lambda (err)
+                                                (declare (ignore err))
+                                               (invoke-restart 'use-value))))
+      (sb-bsd-sockets:socket-bind socket (resolve-hostname host) port))
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 

--- a/slynk/backend/clasp.lisp
+++ b/slynk/backend/clasp.lisp
@@ -229,17 +229,21 @@
     (reader-error                   :read-error)
     (error                          :error)))
 
+(defun %condition-location (origin)
+  ;; NOTE: If we're compiling in a buffer, the origin
+  ;; will already be set up with the offset correctly
+  ;; due to the :source-debug parameters from
+  ;; swank-compile-string (below).
+  (make-file-location
+   (core:file-scope-pathname
+    (core:file-scope origin))
+   (core:source-pos-info-filepos origin)))
+
 (defun condition-location (origin)
-  (if (null origin)
-      (make-error-location "No error location available")
-      ;; NOTE: If we're compiling in a buffer, the origin
-      ;; will already be set up with the offset correctly
-      ;; due to the :source-debug parameters from
-      ;; slynk-compile-string (below).
-      (make-file-location
-       (core:file-scope-pathname
-        (core:file-scope origin))
-       (core:source-pos-info-filepos origin))))
+  (typecase origin
+    (null (make-error-location "No error location available"))
+    (cons (%condition-location (car origin)))
+    (t (%condition-location origin))))
 
 (defun signal-compiler-condition (condition origin)
   (signal 'compiler-condition

--- a/slynk/backend/clasp.lisp
+++ b/slynk/backend/clasp.lisp
@@ -461,7 +461,7 @@
 (defimplementation frame-source-location (frame-number)
   (let ((csl (clasp-debug:frame-source-position (frame-from-number frame-number))))
     (if (clasp-debug:code-source-line-pathname csl)
-        (make-location (list :file (namestring (clasp-debug:code-source-line-pathname csl)))
+        (make-location (list :file (namestring (translate-logical-pathname (clasp-debug:code-source-line-pathname csl))))
                        (list :line (clasp-debug:code-source-line-line-number csl))
                        '(:align t))
         `(:error ,(format nil "No source for frame: ~a" frame-number)))))
@@ -522,7 +522,7 @@
                  `(:align t)))
 
 (defun translate-location (location)
-  (make-location (list :file (namestring (ext:source-location-pathname location)))
+  (make-location (list :file (namestring (translate-logical-pathname (ext:source-location-pathname location))))
                  (list :position (ext:source-location-offset location))
                  '(:align t)))
 

--- a/slynk/backend/clasp.lisp
+++ b/slynk/backend/clasp.lisp
@@ -171,7 +171,7 @@
   (namestring (ext:getcwd)))
 
 (defimplementation quit-lisp ()
-  (core:quit))
+  (sys:quit))
 
 
 
@@ -235,9 +235,9 @@
   ;; due to the :source-debug parameters from
   ;; swank-compile-string (below).
   (make-file-location
-   (core:file-scope-pathname
-    (core:file-scope origin))
-   (core:source-pos-info-filepos origin)))
+   (sys:file-scope-pathname
+    (sys:file-scope origin))
+   (sys:source-pos-info-filepos origin)))
 
 (defun condition-location (origin)
   (typecase origin
@@ -326,7 +326,7 @@
 
 (defimplementation arglist (name)
   (multiple-value-bind (arglist foundp)
-      (core:function-lambda-list name)     ;; Uses bc-split
+      (sys:function-lambda-list name)     ;; Uses bc-split
     (if foundp arglist :not-available)))
 
 (defimplementation function-name (f)
@@ -355,7 +355,7 @@
                 nil)
                ((macro-function (car form) environment)
                 (push form macro-forms))
-               ((not (eq form (core:compiler-macroexpand-1 form environment)))
+               ((not (eq form (sys:compiler-macroexpand-1 form environment)))
                 (push form compiler-macro-forms))))
        form)
      form environment)
@@ -707,15 +707,15 @@
            (sly-dbg "receive-if condition-variable-timedwait")
            (mp:condition-variable-wait (mailbox.cvar mbox) mutex) ; timedwait 0.2
            (sly-dbg "came out of condition-variable-timedwait")
-           (core:check-pending-interrupts)))))
+           (sys:check-pending-interrupts)))))
 
   ) ; #+threads (progn ...
 
 
-(defmethod emacs-inspect ((object core:cxx-object))
-  (let ((encoded (core:encode object)))
+(defmethod emacs-inspect ((object sys:cxx-object))
+  (let ((encoded (sys:encode object)))
     (loop for (key . value) in encoded
        append (list (string key) ": " (list :value value) (list :newline)))))
 
-(defmethod emacs-inspect ((object core:va-list))
-  (emacs-inspect (core:list-from-va-list object)))
+(defmethod emacs-inspect ((object sys:vaslist))
+  (emacs-inspect (sys:list-from-vaslist object)))


### PR DESCRIPTION
This catches up with some recent changes to Clasp and some fixes made to SLIME which were not made here at the same time.

- Replace TMP host with EXT:TEMPORARY-DIRECTORY when available
- Translate logical pathnames in source references
- Change va-list to vaslist and renamed core package
- Clasp uses the USE-VALUE restart to cycle ports