### PR TITLE
Documentation: incorrect *sly-xref* buffer commands

### DIFF
--- a/doc/sly.texi
+++ b/doc/sly.texi
@@ -1181,13 +1181,13 @@ In the resulting @code{*sly-xref*} buffer, these commands are
 available:
 
 @table @kbd
-@kbditem{RET, sly-show-xref}
+@kbditem{Space, sly-xref-show}
 Show definition at point in the other window. Do not leave
-the @code{*sly-xref} buffer.
+the @code{*sly-xref*} buffer.
 
-@kbditem{Space, sly-goto-xref}
+@kbditem{RET, sly-xref-goto}
 Show definition at point in the other window and close
-the @code{*sly-xref} buffer.
+the @code{*sly-xref*} buffer.
 
 @kbditem{C-c C-c, sly-recompile-xref}
 Recompile definition at point. Uses prefix arguments like
@@ -1196,6 +1196,9 @@ Recompile definition at point. Uses prefix arguments like
 @kbditem{C-c C-k, sly-recompile-all-xrefs}
 Recompile all definitions. Uses prefix arguments like
 @code{sly-compile-defun}.
+
+@kbditempair{n, p, M-x sly-xref-next-line, M-x sly-xref-prev-line}
+Move between definitions.
 
 @end table
 


### PR DESCRIPTION
* doc/sly.texi (cross-referencing): The `RET` and `Space` keys are
switched in the `*sly-xref*` buffer commands section of the manual.
Also the function names seems wrong, with `sly-show-xref` instead of
`sly-xref-show`. Finally, the navigation keys `n` and `p` where
missed.

Hope I've not missunderstood. Best regards and thank you for your projects.