### PR TITLE
add support for company-kind

### DIFF
--- a/lib/sly-completion.el
+++ b/lib/sly-completion.el
@@ -291,6 +291,11 @@ ANNOTATION) describing each completion possibility."
                              (when suggestion
                                (delete-region (- (point) (length obj)) (point))
                                (insert suggestion))))
+          :company-kind (lambda (str)
+                          (let* ((annotation (sly-completion-annotation str))
+                                 (kind (car (split-string annotation " " t))))
+                            (intern kind)
+                            ))
           :company-docsig
           (lambda (obj)
             (when (sit-for 0.1)


### PR DESCRIPTION
If we add company-kind support. completion front end such as corfu can get the kind information to implement more feature. 
For my purposes I can use it to make corfu support icon display when pop up the completion frame. 

<img width="488" alt="image" src="https://user-images.githubusercontent.com/38578679/199688607-8a6a38d7-b423-4c66-8ecb-054bc9793754.png">
