### PR TITLE
Don't regexp-quote twice

### DIFF
--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -351,7 +351,7 @@ symbol in the Lisp image if possible."
 (defun sly-package-fu--search-import-from (package)
   (let* ((normalized-package (sly-package-fu--normalize-name package))
          (regexp (format "(:import-from[ \t']*\\(:\\|#:\\)?%s"
-                         (regexp-quote (regexp-quote normalized-package)))))
+                         (regexp-quote normalized-package))))
     (re-search-forward regexp nil t)))
 
 

--- a/test/sly-package-fu-tests.el
+++ b/test/sly-package-fu-tests.el
@@ -3,44 +3,44 @@
 (require 'sly-tests "lib/sly-tests")
 
 (def-sly-test sly-package-fu-sly-import (initial-defpackage final-defpackage symbol)
-              "Check if importing `import` on `initial-defpackage` results in `final-defpackage."
-              '(("(defpackage :foo
+  "Check if importing `import` on `initial-defpackage` results in `final-defpackage."
+  '(("(defpackage :foo
   (:use :cl))
 (in-package :foo)"
-                 "(defpackage :foo
+     "(defpackage :foo
   (:use :cl)
   (:import-from #:cl
                 #:find))
 (in-package :foo)"
-                 "cl:find")
-                ("(defpackage :foo
+     "cl:find")
+    ("(defpackage :foo
   (:use :cl)
   (:import-from #:cl
                 #:find))
 (in-package :foo)"
-                 "(defpackage :foo
+     "(defpackage :foo
   (:use :cl)
   (:import-from #:cl
                 #:position
                 #:find))
 (in-package :foo)"
-                 "cl:position")
+     "cl:position")
 
-                ;; TODO: the output here is incorrect, but we're
-                ;; documenting the current behaviour in this test.
-                ("(defpackage :foo
+    ;; TODO: the output here is incorrect, but we're
+    ;; documenting the current behaviour in this test.
+    ("(defpackage :foo
   (:use :cl)
   (:import-from #:bknr.datastore
                 #:find))
 (in-package :foo)"
-                 "(defpackage :foo
+     "(defpackage :foo
   (:use :cl)
   (:import-from #:bknr.datastore
                 #:find)
   (:import-from #:bknr.datastore
                 #:position))
 (in-package :foo)"
-                 "bknr.datastore:position"))
+     "bknr.datastore:position"))
   (let ((file (make-temp-file "sly-package-fu--fixture")))
     (with-temp-buffer
       (find-file file)

--- a/test/sly-package-fu-tests.el
+++ b/test/sly-package-fu-tests.el
@@ -25,9 +25,6 @@
                 #:find))
 (in-package :foo)"
      "cl:position")
-
-    ;; TODO: the output here is incorrect, but we're
-    ;; documenting the current behaviour in this test.
     ("(defpackage :foo
   (:use :cl)
   (:import-from #:bknr.datastore-dummy
@@ -36,9 +33,8 @@
      "(defpackage :foo
   (:use :cl)
   (:import-from #:bknr.datastore-dummy
-                #:find)
-  (:import-from #:bknr.datastore-dummy
-                #:position))
+                #:position
+                #:find))
 (in-package :foo)"
      "bknr.datastore-dummy:position"))
   (let ((file (make-temp-file "sly-package-fu--fixture")))

--- a/test/sly-package-fu-tests.el
+++ b/test/sly-package-fu-tests.el
@@ -1,0 +1,54 @@
+;; -*- lexical-binding: t; -*-
+(require 'sly-package-fu "contrib/sly-package-fu")
+(require 'sly-tests "lib/sly-tests")
+
+(def-sly-test sly-package-fu-sly-import (initial-defpackage final-defpackage symbol)
+              "Check if importing `import` on `initial-defpackage` results in `final-defpackage."
+              '(("(defpackage :foo
+  (:use :cl))
+(in-package :foo)"
+                 "(defpackage :foo
+  (:use :cl)
+  (:import-from #:cl
+                #:find))
+(in-package :foo)"
+                 "cl:find")
+                ("(defpackage :foo
+  (:use :cl)
+  (:import-from #:cl
+                #:find))
+(in-package :foo)"
+                 "(defpackage :foo
+  (:use :cl)
+  (:import-from #:cl
+                #:position
+                #:find))
+(in-package :foo)"
+                 "cl:position")
+
+                ;; TODO: the output here is incorrect, but we're
+                ;; documenting the current behaviour in this test.
+                ("(defpackage :foo
+  (:use :cl)
+  (:import-from #:bknr.datastore
+                #:find))
+(in-package :foo)"
+                 "(defpackage :foo
+  (:use :cl)
+  (:import-from #:bknr.datastore
+                #:find)
+  (:import-from #:bknr.datastore
+                #:position))
+(in-package :foo)"
+                 "bknr.datastore:position"))
+  (let ((file (make-temp-file "sly-package-fu--fixture")))
+    (with-temp-buffer
+      (find-file file)
+      (lisp-mode)
+      (setq indent-tabs-mode nil)
+      (insert initial-defpackage)
+      (sly-package-fu--add-or-update-import-from-form symbol)
+      (should (equal final-defpackage
+                     (buffer-string))))))
+
+(provide 'sly-package-fu-tests)

--- a/test/sly-package-fu-tests.el
+++ b/test/sly-package-fu-tests.el
@@ -30,17 +30,17 @@
     ;; documenting the current behaviour in this test.
     ("(defpackage :foo
   (:use :cl)
-  (:import-from #:bknr.datastore
+  (:import-from #:bknr.datastore-dummy
                 #:find))
 (in-package :foo)"
      "(defpackage :foo
   (:use :cl)
-  (:import-from #:bknr.datastore
+  (:import-from #:bknr.datastore-dummy
                 #:find)
-  (:import-from #:bknr.datastore
+  (:import-from #:bknr.datastore-dummy
                 #:position))
 (in-package :foo)"
-     "bknr.datastore:position"))
+     "bknr.datastore-dummy:position"))
   (let ((file (make-temp-file "sly-package-fu--fixture")))
     (with-temp-buffer
       (find-file file)


### PR DESCRIPTION
This was first introduced in c53e699aa4340d93f1784b79e7280390247af721 cc @svetlyak40wt 

I can't tell if there's a specific purpose to the multiple regexp-quotes, but currently it fails on things with '.' (for instance, if I import multiple things from `bknr.datastore` it'll create separate `:import-from` for this. e.g. https://github.com/screenshotbot/screenshotbot-oss/blob/177e189ad3b2dc3811c17435013076e893959512/src/util/store-version.lisp#L9

There's one more bug in this regexp that I want to fix in a follow commit.