### PR TITLE
Use WITH-STANDARD-IO-SYNTAX for reading literals

### DIFF
--- a/slynk/backend/abcl.lisp
+++ b/slynk/backend/abcl.lisp
@@ -88,7 +88,7 @@
 ;;; and potentially with other REPLs, we export a functional toggle
 ;;; for the user to call after loading these definitions.
 (defun enable-cl-inspect-in-emacs ()
-  (slynk-backend:wrap 'cl:inspect :use-sly :replace (read-from-string "slynk:inspect-in-emacs")))
+  (slynk-backend:wrap 'cl:inspect :use-sly :replace (with-standard-io-syntax (read-from-string "slynk:inspect-in-emacs")))
 
 ;; ??? repair bare print object so inspector titles show java class
 (defun %print-unreadable-object-java-too (object stream type identity body)
@@ -480,7 +480,7 @@
                                    (first (sys:frame-to-list frame)))))
             (car sys::*saved-backtrace*)))
          #+#.(slynk-backend:with-symbol *debug-condition* 'ext)
-         (ext::*debug-condition* (read-from-string "slynk::*slynk-debugger-condition*")))
+         (ext::*debug-condition* (with-standard-io-syntax (read-from-string "slynk::*slynk-debugger-condition*")))
     (funcall debugger-loop-fn)))
 
 (defun backtrace (start end)

--- a/slynk/backend/allegro.lisp
+++ b/slynk/backend/allegro.lisp
@@ -773,7 +773,7 @@ to do this, this factors in the length of the inserted header itself."
           (saved-ynp (symbol-function 'cl:y-or-n-p)))
      (setf (excl::package-definition-lock pkg) nil
            (symbol-function 'cl:y-or-n-p)
-           (symbol-function (read-from-string "slynk:y-or-n-p-in-emacs")))
+           (symbol-function (with-standard-io-syntax (read-from-string "slynk:y-or-n-p-in-emacs")))
      (unwind-protect
           (progn ,@body)
        (setf (symbol-function 'cl:y-or-n-p)      saved-ynp

--- a/slynk/backend/clasp.lisp
+++ b/slynk/backend/clasp.lisp
@@ -19,7 +19,7 @@
 ;;    (set slynk:*log-events* t))
 
 (defmacro sly-dbg (fmt &rest args)
-  `(funcall (read-from-string "slynk::log-event")
+  `(funcall (with-standard-io-syntax (read-from-string "slynk::log-event"))
             "sly-dbg ~a ~a~%" mp:*current-process* (apply #'format nil ,fmt ,args)))
 
 ;; Hard dependencies.

--- a/slynk/backend/lispworks.lisp
+++ b/slynk/backend/lispworks.lisp
@@ -139,10 +139,10 @@
     (error "Cannot use external format ~A~
             without having installed flexi-streams in the inferior-lisp."
            external-format))
-  (funcall (read-from-string "FLEXI-STREAMS:MAKE-FLEXI-STREAM")
+  (funcall (with-standard-io-syntax (read-from-string "FLEXI-STREAMS:MAKE-FLEXI-STREAM"))
            stream
            :external-format
-           (apply (read-from-string "FLEXI-STREAMS:MAKE-EXTERNAL-FORMAT")
+           (apply (with-standard-io-syntax (read-from-string "FLEXI-STREAMS:MAKE-EXTERNAL-FORMAT"))
                   external-format)))
 
 ;;; Coding Systems

--- a/slynk/backend/mkcl.lisp
+++ b/slynk/backend/mkcl.lisp
@@ -154,7 +154,7 @@
 (defvar *inferior-lisp-sleeping-post* nil)
 
 (defimplementation quit-lisp ()
-  (progf (ignore-errors (eval (read-from-string "slynk::*saved-global-streams*"))) ;; restore original IO streams.
+  (progf (ignore-errors (eval (with-standard-io-syntax (read-from-string "slynk::*saved-global-streams*"))) ;; restore original IO streams.
          (when *inferior-lisp-sleeping-post* (mt:semaphore-signal *inferior-lisp-sleeping-post*))
          ;;(mk-ext:quit :verbose t)
          ))

--- a/slynk/slynk-apropos.lisp
+++ b/slynk/slynk-apropos.lisp
@@ -121,12 +121,12 @@ that symbols accessible in the current package go first."
       (cond ((find-package :cl-ppcre)
              (background-message "Using CL-PPCRE for apropos on regexp \"~a\"" pattern)
 
-             (let ((matcher (funcall (read-from-string "cl-ppcre:create-scanner")
+             (let ((matcher (funcall (with-standard-io-syntax (read-from-string "cl-ppcre:create-scanner"))
                                      pattern
                                      :case-insensitive-mode (not case-sensitive))))
                (lambda (symbol-name)
                  (multiple-value-bind (beg end)
-                     (funcall (read-from-string "cl-ppcre:scan")
+                     (funcall (with-standard-io-syntax (read-from-string "cl-ppcre:scan"))
                               matcher
                               symbol-name)
                    (when beg `((,beg ,end)))))))

--- a/slynk/slynk-backend.lisp
+++ b/slynk/slynk-backend.lisp
@@ -1479,8 +1479,8 @@ Return :interrupt if an interrupt occurs while waiting."
      (error
       "~s not implemented. Check if ~s = ~s is supported by the implementation."
       'wait-for-input
-      (read-from-string "SLYNK:*COMMUNICATION-STYLE*")
-      (symbol-value (read-from-string "SLYNK:*COMMUNICATION-STYLE*"))))))
+      (with-standard-io-syntax (read-from-string "SLYNK:*COMMUNICATION-STYLE*"))
+      (symbol-value (with-standard-io-syntax (read-from-string "SLYNK:*COMMUNICATION-STYLE*")))))))
 
 
 ;;;;  Locks

--- a/slynk/slynk-source-path-parser.lisp
+++ b/slynk/slynk-source-path-parser.lisp
@@ -142,7 +142,7 @@ subexpressions of the object to stream positions."
 (defun readtable-for-package (package)
   ;; KLUDGE: due to the load order we can't reference the slynk
   ;; package.
-  (funcall (read-from-string "slynk::guess-buffer-readtable")
+  (funcall (with-standard-io-syntax (read-from-string "slynk::guess-buffer-readtable"))
            (string-upcase (package-name package))))
 
 ;; Search STREAM for a "(in-package ...)" form.  Use that to derive

--- a/slynk/slynk.asd
+++ b/slynk/slynk.asd
@@ -79,7 +79,7 @@
 
 (defmethod perform :after ((o load-op) (c (eql (find-system :slynk))))
   (format *debug-io* "~&SLYNK's ASDF loader finished.")
-  (funcall (read-from-string "slynk::init")))
+  (funcall (with-standard-io-syntax (read-from-string "slynk::init"))))
 
 
 ;;; Contrib systems (should probably go into their own file one day)


### PR DESCRIPTION
Add robustness to symbol lookups of the form:

    (read-from-string "a-package::a-symbol")

by giving them stable reader settings:

    (with-standard-io-syntax ...)

so that they work the same independent of the reader settings in the image.

(I noticed that SLY compile commands stopped working when I was using named-readtables and :PRESERVE case. SLYNK would start looking for symbols with lowercase symbol-names.)