### PR TITLE
Autoload `sly-mrepl`

### DIFF
--- a/contrib/sly-mrepl.el
+++ b/contrib/sly-mrepl.el
@@ -969,6 +969,7 @@ arglist for the most recently enclosed macro or function."
 (put 'sly-mrepl-next-input-or-button 'sly-button-navigation-command t)
 (put 'sly-mrepl-previous-input-or-button 'sly-button-navigation-command t)
 
+;;;###autoload
 (defun sly-mrepl (&optional display-action)
   "Find or create the first useful REPL for the default connection.
 If supplied, DISPLAY-ACTION is called on the


### PR DESCRIPTION
This allows `commandp` to return T for `sly-mrepl`, even when the library is not yet loaded. Note that other top-level functions in Sly are already autoloaded, like the `sly` function itself, so there is precedent. 