### PR TITLE
Fix sly-db-invoke-restart-by-name fails because it uses unknown 'first

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -6102,7 +6102,7 @@ Interactively get the number from a button at point."
                                         ""
                                         'sly-db-invoke-restart-by-name))))
   (sly-db-invoke-restart (cl-position restart-name sly-db-restarts
-                                      :test 'string= :key 'first)))
+                                      :test 'string= :key #'cl-first)))
 
 (defun sly-db-break-with-default-debugger (&optional dont-unwind)
   "Enter default debugger."


### PR DESCRIPTION
Fix for sly-db-invoke-restart-by-name failure due to its trying to use unknown 'first instead of #'cl-first.