### PR TITLE
Add basic tests for sly-package-fu

### DIFF
--- a/test/sly-package-fu-tests.el
+++ b/test/sly-package-fu-tests.el
@@ -3,44 +3,44 @@
 (require 'sly-tests "lib/sly-tests")
 
 (def-sly-test sly-package-fu-sly-import (initial-defpackage final-defpackage symbol)
-              "Check if importing `import` on `initial-defpackage` results in `final-defpackage."
-              '(("(defpackage :foo
+  "Check if importing `import` on `initial-defpackage` results in `final-defpackage."
+  '(("(defpackage :foo
   (:use :cl))
 (in-package :foo)"
-                 "(defpackage :foo
+     "(defpackage :foo
   (:use :cl)
   (:import-from #:cl
                 #:find))
 (in-package :foo)"
-                 "cl:find")
-                ("(defpackage :foo
+     "cl:find")
+    ("(defpackage :foo
   (:use :cl)
   (:import-from #:cl
                 #:find))
 (in-package :foo)"
-                 "(defpackage :foo
+     "(defpackage :foo
   (:use :cl)
   (:import-from #:cl
                 #:position
                 #:find))
 (in-package :foo)"
-                 "cl:position")
+     "cl:position")
 
-                ;; TODO: the output here is incorrect, but we're
-                ;; documenting the current behaviour in this test.
-                ("(defpackage :foo
+    ;; TODO: the output here is incorrect, but we're
+    ;; documenting the current behaviour in this test.
+    ("(defpackage :foo
   (:use :cl)
   (:import-from #:bknr.datastore
                 #:find))
 (in-package :foo)"
-                 "(defpackage :foo
+     "(defpackage :foo
   (:use :cl)
   (:import-from #:bknr.datastore
                 #:find)
   (:import-from #:bknr.datastore
                 #:position))
 (in-package :foo)"
-                 "bknr.datastore:position"))
+     "bknr.datastore:position"))
   (let ((file (make-temp-file "sly-package-fu--fixture")))
     (with-temp-buffer
       (find-file file)

--- a/test/sly-package-fu-tests.el
+++ b/test/sly-package-fu-tests.el
@@ -1,0 +1,54 @@
+;; -*- lexical-binding: t; -*-
+(require 'sly-package-fu "contrib/sly-package-fu")
+(require 'sly-tests "lib/sly-tests")
+
+(def-sly-test sly-package-fu-sly-import (initial-defpackage final-defpackage symbol)
+              "Check if importing `import` on `initial-defpackage` results in `final-defpackage."
+              '(("(defpackage :foo
+  (:use :cl))
+(in-package :foo)"
+                 "(defpackage :foo
+  (:use :cl)
+  (:import-from #:cl
+                #:find))
+(in-package :foo)"
+                 "cl:find")
+                ("(defpackage :foo
+  (:use :cl)
+  (:import-from #:cl
+                #:find))
+(in-package :foo)"
+                 "(defpackage :foo
+  (:use :cl)
+  (:import-from #:cl
+                #:position
+                #:find))
+(in-package :foo)"
+                 "cl:position")
+
+                ;; TODO: the output here is incorrect, but we're
+                ;; documenting the current behaviour in this test.
+                ("(defpackage :foo
+  (:use :cl)
+  (:import-from #:bknr.datastore
+                #:find))
+(in-package :foo)"
+                 "(defpackage :foo
+  (:use :cl)
+  (:import-from #:bknr.datastore
+                #:find)
+  (:import-from #:bknr.datastore
+                #:position))
+(in-package :foo)"
+                 "bknr.datastore:position"))
+  (let ((file (make-temp-file "sly-package-fu--fixture")))
+    (with-temp-buffer
+      (find-file file)
+      (lisp-mode)
+      (setq indent-tabs-mode nil)
+      (insert initial-defpackage)
+      (sly-package-fu--add-or-update-import-from-form symbol)
+      (should (equal final-defpackage
+                     (buffer-string))))))
+
+(provide 'sly-package-fu-tests)

--- a/test/sly-package-fu-tests.el
+++ b/test/sly-package-fu-tests.el
@@ -30,17 +30,17 @@
     ;; documenting the current behaviour in this test.
     ("(defpackage :foo
   (:use :cl)
-  (:import-from #:bknr.datastore
+  (:import-from #:bknr.datastore-dummy
                 #:find))
 (in-package :foo)"
      "(defpackage :foo
   (:use :cl)
-  (:import-from #:bknr.datastore
+  (:import-from #:bknr.datastore-dummy
                 #:find)
-  (:import-from #:bknr.datastore
+  (:import-from #:bknr.datastore-dummy
                 #:position))
 (in-package :foo)"
-     "bknr.datastore:position"))
+     "bknr.datastore-dummy:position"))
   (let ((file (make-temp-file "sly-package-fu--fixture")))
     (with-temp-buffer
       (find-file file)


### PR DESCRIPTION
This is a no-op change that just adds a new test for sly-package-fu. We'll use this to demonstrate the issue in PR #560.

I ran these tests as `make check-fancy`. Let me know if that's the incorrect way of running tests, because on Emacs 28.0.50, a few of these tests are failing:

```
Ran 166 tests, 162 results as expected, 3 unexpected, 1 skipped (2023-04-23 16:58:01-0400, 3.024471 sec)
1 expected failures

3 unexpected results:
   FAILED  autodoc-tests-25
   FAILED  autodoc-tests-26
   FAILED  font-lock-magic-3

1 skipped results:
  SKIPPED  autodoc-space-1
```

On Emacs 30, a bunch of tests are failing, so I'm assuming that's not a supported version.