### PR TITLE
Always search for the full package name in existing IMPORT-FROMs

### DIFF
--- a/contrib/sly-package-fu.el
+++ b/contrib/sly-package-fu.el
@@ -350,10 +350,15 @@ symbol in the Lisp image if possible."
 ;;
 
 (defun sly-package-fu--search-import-from (package)
+  "Moves point to the end of the package name corresponding to
+the (:IMPORT-FROM) for package. If no such import-from exists,
+returns nil."
   (let* ((normalized-package (sly-package-fu--normalize-name package))
-         (regexp (format "(:import-from[ \t']*\\(:\\|#:\\)?%s"
+         (regexp (format "(:import-from[ \t']*\\(:\\|#:\\)?%s[[:space:]]"
                          (regexp-quote normalized-package))))
-    (re-search-forward regexp nil t)))
+    (when (re-search-forward regexp nil t)
+      (goto-char (- (point) 1))
+      (point))))
 
 
 (defun sly-package-fu--create-new-import-from (package symbol)

--- a/test/sly-package-fu-tests.el
+++ b/test/sly-package-fu-tests.el
@@ -15,8 +15,22 @@
                                      :position
                                      :find))
       (in-package :foo))
-     bknr.datastore-dummy::position))
-  (let ((file (make-temp-file "sly-package-fu--fixture")))
+     bknr.datastore-dummy::position)
+    (((defpackage :foo
+        (:import-from :bar/car :find))
+      (in-package :foo))
+     ((defpackage :foo
+        (:import-from :bar/car :find)
+        (:import-from :bar :position))
+      (in-package :foo))
+     bar::position))
+  (let ((file (make-temp-file "sly-package-fu--fixture"))
+        (sly-export-symbol-representation-auto nil)
+        (sly-export-symbol-representation-function
+         ;; For the purpose of these tests, reading back the
+         ;; #:.. style symbols breaks equality, since they are
+         ;; uninterned.
+         (lambda (n) (format ":%s" n))))
     (with-temp-buffer
       (find-file file)
       (lisp-mode)
@@ -25,11 +39,40 @@
       ;; FIXME: using internal implementation detail
       (sly-package-fu--add-or-update-import-from-form
        (pp-to-string symbol-to-import))
+
+      (message "%s" final)
+      (message "%s" (cl-loop initially (goto-char (point-min))
+                             for f = (ignore-errors (read (current-buffer)))
+                             while f collect f))
       (should (equal final
                      (cl-loop initially (goto-char (point-min))
                               for f = (ignore-errors (read (current-buffer)))
                               while f collect f))))))
 
+(define-sly-ert-test package-fu-jumps-to-import-from-happy-path ()
+  (with-temp-buffer
+    (insert "(defpackage :foo (:import-from #:bar #:car))")
+    ;; Expect to be here:........................^
+    (goto-char (point-min))
+    (sly-package-fu--search-import-from "bar")
+    (should (equal 37 (point)))))
+
+(define-sly-ert-test package-fu-jumps-to-import-from-with-new-line ()
+  (with-temp-buffer
+    (insert "(defpackage :foo (:import-from #:bar\n#:car))")
+    ;; Expect to be here:........................^
+    (goto-char (point-min))
+    (sly-package-fu--search-import-from "bar")
+    (should (equal 37 (point)))))
+
+(define-sly-ert-test package-fu-does-not-jump-to-package-prefix ()
+  (with-temp-buffer
+    (insert "(defpackage :foo (:import-from #:barcelona\n#:car))")
+    (goto-char (point-min))
+    (should
+     (equal nil
+            (sly-package-fu--search-import-from "bar")))
+    (should (equal 1 (point)))))
 
 
 (provide 'sly-package-fu-tests)


### PR DESCRIPTION
.. As opposed to just looking at prefixes. Previously, If you had an existing defpackage like this:

(defpakage :foo
  (:import-from :bar/car
                :find)))

And you imported bar::position, you'll end up with something ugly like this:

(defpackage :foo
  (:import-from :bar
                :position/car
                :find))