### PR TITLE
Show CPU usage and time since thread started to sly-threads view

### DIFF
--- a/slynk/backend/sbcl.lisp
+++ b/slynk/backend/sbcl.lisp
@@ -1708,6 +1708,9 @@ stack."
         "Running"
         "Stopped"))
 
+  (defimplementation thread-attributes (thread)
+    (list :tid (sb-thread:thread-os-tid thread)))
+
   (defimplementation make-lock (&key name)
     (sb-thread:make-mutex :name name))
 


### PR DESCRIPTION
I was debugging a multi-threaded program where some threads would hang at 100% cpu so I added some extra info to the thread view to spot it easier. It is only for sbcl and linux. Supporting other compilers and OS I think is possible if there is interest and someone available to test. I first added to the sbcl backend `thread-attributes` a `:tid` attribute with the OS `tid`/`pid` for each thread. Then on the elisp side if the `:tid` attribute is present, it will also add the elapsed time since the thread started, and the percent cpu usage since the last update of the threads buffer. The elapsed time it gets from emacs `process-attributes` function which is cross platform, however the cpu time returned by emacs 'process-attributes' for a given `tid` is for the process not the thread. As on linux emacs is reading `/proc/tid/stat` which does have the correct elapsed time per thread but has the cpu usage for the whole process, so I added a function to get the info from `/proc/sly-pid/task/tid/stat`

Here's a screenshot of it in action:
![2023-05-14-145740_1156x442_scrot](https://github.com/joaotavora/sly/assets/122528427/70f66dea-5aa7-4de1-9a96-2f0d0f90fa31)

I'm thinking maybe I should remove the TID column cause the user probably doesn't care to see it, and make the time show in a nice format, I could just call `proced-format-time` but then sly would have to require proced.

Is just an idea and demo of it, I doubt it's of quality to merge into sly as is, I'm new at emacs and lisp so any feedback is welcome.