### PR TITLE
Export SLYNK-BACKEND:NETWORK-ERROR condition

### DIFF
--- a/slynk/slynk-backend.lisp
+++ b/slynk/slynk-backend.lisp
@@ -13,6 +13,7 @@
 (defpackage slynk-backend
   (:use cl)
   (:export *debug-slynk-backend*
+           network-error
            sly-db-condition
            compiler-condition
            original-condition


### PR DESCRIPTION
* slynk/slynk-backend.lisp
* slynk/backend/lispworks.lisp (create-socket): Fix signaling socket creation errors.