### PR TITLE
sly-button-define-part-action: Pass 'no-error to ‘sly-button-at’

### DIFF
--- a/lib/sly-buttons.el
+++ b/lib/sly-buttons.el
@@ -79,7 +79,7 @@
          `((define-key sly-part-button-keymap ,key
              '(menu-item "" ,action
                          :filter (lambda (cmd)
-                                   (let ((button (sly-button-at)))
+                                   (let ((button (sly-button-at nil nil 'no-error)))
                                      (and button
                                           (button-get button ',action)
                                           cmd)))))))

--- a/lib/sly-buttons.el
+++ b/lib/sly-buttons.el
@@ -85,7 +85,7 @@
                                           cmd)))))))
      (define-key sly-button-popup-part-menu-keymap
        [,action] '(menu-item ,label ,action
-                             :visible (let ((button (sly-button-at)))
+                             :visible (let ((button (sly-button-at nil nil 'no-error)))
                                         (and button
                                              (button-get button ',action)))))))
 


### PR DESCRIPTION
I ran into the issue described in https://github.com/joaotavora/sly/issues/466 and this seems to fix it.  This might be a nicer fix than the existing PR, given that it might have unintended side-effects to change or remove `sly-db-frame-map`'s parent keymap.