### PR TITLE
Consistently use keyword arguments when defining minor modes

### DIFF
--- a/contrib/sly-autodoc.el
+++ b/contrib/sly-autodoc.el
@@ -167,7 +167,7 @@ If it's not in the cache, the cache will be updated asynchronously."
 
 (define-minor-mode sly-autodoc-mode
   "Toggle echo area display of Lisp objects at point."
-  nil nil nil
+  :global nil
   (cond (sly-autodoc-mode
          (set (make-local-variable 'eldoc-documentation-function) 'sly-autodoc)
          (set (make-local-variable 'eldoc-minor-mode-string) "")

--- a/contrib/sly-trace-dialog.el
+++ b/contrib/sly-trace-dialog.el
@@ -122,7 +122,7 @@ inspecting details of traced functions. Invoke this dialog with C-c T."
 
 (define-minor-mode sly-trace-dialog-hide-details-mode
   "Hide details in `sly-trace-dialog-mode'"
-  nil " Brief"
+  :lighter " Brief"
   :group 'sly-trace-dialog
   (unless (derived-mode-p 'sly-trace-dialog-mode)
     (error "Not a SLY Trace Dialog buffer"))
@@ -130,7 +130,7 @@ inspecting details of traced functions. Invoke this dialog with C-c T."
 
 (define-minor-mode sly-trace-dialog-autofollow-mode
   "Automatically inspect trace entries from `sly-trace-dialog-mode'"
-  nil " Autofollow"
+  :lighter " Autofollow"
   :group 'sly-trace-dialog
   (unless (derived-mode-p 'sly-trace-dialog-mode)
     (error "Not a SLY Trace Dialog buffer")))

--- a/lib/sly-buttons.el
+++ b/lib/sly-buttons.el
@@ -311,7 +311,7 @@ or leave at `identity' to visit every `sly-button' in the buffer.'")
 
 (define-minor-mode sly-interactive-buttons-mode
   "Minor mode where text property SLY buttons exist"
-  nil nil nil
+  :global nil
   ;; Prevent strings copied from SLY buffers and yanked to source
   ;; buffers to land with misleading `sly-' properties.
   (when (fboundp 'add-function)

--- a/sly.el
+++ b/sly.el
@@ -587,7 +587,7 @@ interactive command.\".")
 ;;;###autoload
 (define-minor-mode sly-mode
   "Minor mode for horizontal SLY functionality."
-  nil nil nil
+  :global nil
   ;; Company-mode should have this by default
   ;; See gh#166
   (set (make-local-variable 'company-tooltip-align-annotations) t))
@@ -601,13 +601,13 @@ interactive command.\".")
 ;;;###autoload
 (define-minor-mode sly-editing-mode
   "Minor mode for editing `lisp-mode' buffers."
-  nil nil nil
+  :global nil
   (sly-mode 1)
   (setq-local lisp-indent-function #'sly--lisp-indent-function))
 
 (define-minor-mode sly-popup-buffer-mode
   "Minor mode for all read-only SLY buffers"
-  nil nil nil
+  :global nil
   (sly-mode 1)
   (sly-interactive-buttons-mode 1)
   (setq buffer-read-only t))
@@ -4327,9 +4327,8 @@ in Lisp when committed with \\[sly-edit-value-commit]."
 
 (define-minor-mode sly-edit-value-mode
   "Mode for editing a Lisp value."
-  nil
-  " Edit-Value"
-  '(("\C-c\C-c" . sly-edit-value-commit)))
+  :keymap '(("\C-c\C-c" . sly-edit-value-commit))
+  :lighter " Edit-Value")
 
 (defun sly-edit-value-callback (form-string current-value package)
   (let* ((name (generate-new-buffer-name (format "*Edit %s*" form-string)))
@@ -5042,9 +5041,7 @@ Uses prefix arguments like `sly-compile-defun'."
 
 (define-minor-mode sly-macroexpansion-minor-mode
   "SLY mode for macroexpansion"
-  nil
-  " Macroexpand"
-  nil
+  :lighter " Macroexpand"
   (read-only-mode 1))
 
 (defun sly-macroexpand-undo (&optional arg)


### PR DESCRIPTION
Since Emacs 30 (?) not doing this appears to trigger a warning during byte compilation.