### PR TITLE
sly-eval-print: Don't hardcode comment size

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -4213,7 +4213,7 @@ kill ring."
                              ""
                            " => ") value)
           (unless string-or-comment-p
-            (comment-region start (point) 1)))))))
+            (comment-region start (point))))))))
 
 (defun sly-eval-save (string)
   "Evaluate STRING in Lisp and save the result in the kill ring."


### PR DESCRIPTION
I'm often using `sly-eval-print` for a kind of literate programming workflow of evaluating forms one after the other and printing results inline. One particular thing that makes this workflow uncomfortable is that `sly-eval-print` prints the result with a single colon. This single colon is:
- Often improperly indented by SLY itself.
- Is against the convention that one-semicolon comments are strictly the inline ones. 
  - Block comments (two semicolons) make more sense for result printing with line break.
- And then it's hard-coded, which makes it much less customizable by user. `comment-region` has a lot of customizations, so the result of  `sly-eval-print` might be really far from what one might expect in their code comments.

This PR removes the hard-coded prefix arg, so that `sly-eval-print` comments are more customizable, consistent, and semantically correct.