### PR TITLE
Fix #470: Handle case when there is no emacs-connection.

### DIFF
--- a/slynk/slynk.lisp
+++ b/slynk/slynk.lisp
@@ -3942,7 +3942,8 @@ after each command.")
        (handle-indentation-cache-request c request))
       (multithreaded-connection
        (without-sly-interrupts
-         (send (mconn.indentation-cache-thread c) request))))))
+         (send (mconn.indentation-cache-thread c) request)))
+      (null t))))
 
 (defun indentation-cache-loop (connection)
   (with-connection (connection)


### PR DESCRIPTION
Closes #470.

My use-case is as follows: Nyxt depends on `slynk/indentation` and `lass`, which in turn calls `indent:define-indentation` from `trivial-indent`. Without this fix, it would raise the error below.

```lisp
debugger invoked on a SB-KERNEL:CASE-FAILURE @5436DF2E in thread
#<THREAD tid=19916 "main thread" RUNNING {10017401B3}>:
  NIL fell through ETYPECASE expression.
  Wanted one of (SLYNK::SINGLETHREADED-CONNECTION
                 SLYNK::MULTITHREADED-CONNECTION).

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [TRY-RECOMPILING              ] Recompile special and try loading it again
  1: [RETRY                        ] Retry
                                     loading FASL for #<CL-SOURCE-FILE "lass" "special">.
  2: [ACCEPT                       ] Continue, treating
                                     loading FASL for #<CL-SOURCE-FILE "lass" "special">
                                     as having been successful.
  3:                                 Retry ASDF operation.
  4: [CLEAR-CONFIGURATION-AND-RETRY] Retry ASDF operation after resetting the
                                     configuration.
  5:                                 Retry ASDF operation.
  6:                                 Retry ASDF operation after resetting the
                                     configuration.
  7: [RETRY                        ] Retry EVAL of current toplevel form.
  8: [CONTINUE                     ] Ignore error and continue loading file "/gnu/store/qk4jx7p95ff6iyr4pn6h7bvh599hjj54-profile/bin/lisp-repl-core-dumper".
  9: [ABORT                        ] Abort loading file "/gnu/store/qk4jx7p95ff6iyr4pn6h7bvh599hjj54-profile/bin/lisp-repl-core-dumper".
 10:                                 Ignore runtime option --eval "(with-open-file (s \"/gnu/store/qk4jx7p95ff6iyr4pn6h7bvh599hjj54-profile/bin/lisp-repl-core-dumper\")
  (read-line s)
  (load s))".
 11:                                 Skip rest of --eval and --load options.
 12:                                 Skip to toplevel READ/EVAL/PRINT loop.
 13: [EXIT                         ] Exit SBCL (calling #'EXIT, killing the process).

(SLYNK::SEND-TO-INDENTATION-CACHE (:UPDATE-INDENTATION-INFORMATION))
   source: (ETYPECASE C
             (SINGLETHREADED-CONNECTION
              (HANDLE-INDENTATION-CACHE-REQUEST C REQUEST))
             (MULTITHREADED-CONNECTION
              (WITHOUT-SLY-INTERRUPTS
               (SEND (MCONN.INDENTATION-CACHE-THREAD C) REQUEST))))
0] 
```