### PR TITLE
Implement sly-media.el

### DIFF
--- a/contrib/sly-media.el
+++ b/contrib/sly-media.el
@@ -1,0 +1,51 @@
+;;; -*-lexical-binding:t-*-
+(require 'sly)
+(require 'cl-lib)
+
+(define-sly-contrib sly-media
+  "Display images in SLY buffers"
+  (:authors "Jin-Cheng Guu <jcguu95@gmail.com>")
+  (:license "GPL")
+  ;; (:on-load
+  ;;  (add-hook 'sly-event-hooks 'sly-dispatch-media-event))
+  )
+
+(defun sly-media-insert-image (image string)
+  "Insert image into the current sly buffer. Example Usage:
+(1) Define function in the Lisp that connects to the current sly buffer.
+    ; (defun display-image-on-disk (filename)
+    ;   \"Displays an image in the current sly buffer.\"
+    ;   (slynk:eval-in-emacs
+    ;    `(sly-media-insert-image
+    ;      (create-image ,filename) ,filename)))
+(2) Evaluate in emacs: (setq sly-enable-evaluate-in-emacs t)
+(3) Evaluate in the sly buffer: (display-image-on-disk \"/tmp/example.jpg\")
+"
+  (with-current-buffer
+      (get-buffer (sly-buffer-name :mrepl :connection (sly-current-connection)))
+    (let ((marker (sly-mrepl--mark)))
+      (goto-char marker)
+      (sly-propertize-region `(face slime-mrepl-output-face
+                               rear-nonsticky (face))
+        (insert-image image string))
+      (set-marker marker (point)))
+    nil))
+
+;; (defun sly-dispatch-media-event (event)
+;;   (sly-dcase event
+;;     ((:write-image image string)
+;;      (cl-labels
+;;          ((media-decode-image (image)
+;;             (mapcar (lambda (image)
+;;                       (if (plist-get image :data)
+;;                           (plist-put image :data (base64-decode-string
+;;                                                   (plist-get image :data)))
+;;                         image))
+;;                     image)))
+;;        (let ((img (or (find-image (media-decode-image image))
+;;                       (create-image image))))
+;;          (sly-media-insert-image img string)))
+;;      t)
+;;     (t nil)))
+
+(provide 'sly-media)

--- a/doc/contributors.texi
+++ b/doc/contributors.texi
@@ -28,4 +28,5 @@
 @item Douglas Katzman @tab Dmitry Igrishin @tab Dmitrii Korobeinikov
 @item Deokhwan Kim @tab Denis Budyak @tab Chunyang Xu
 @item Cayman @tab Angelo Rossi @tab Andrew Kirkpatrick
+@item Jin-Cheng Guu
 @end multitable


### PR DESCRIPTION
Thank [svetlyak40wt](https://github.com/svetlyak40wt) for bringing up the [issue](https://github.com/joaotavora/sly/issues/629)! With a few tweaks, `slime-media.el` is now ported to sly in this contrib! 

With this contrib, we can display image on disk in sly buffers. We can also call that from a Lisp that connects to the sly buffer following the steps below.

1. Define function in the Lisp that connects to the current sly buffer.

``` lisp
(defun display-image-on-disk (filename)
  \"Displays an image in the current sly buffer.\"
  (slynk:eval-in-emacs
   `(sly-media-insert-image
     (create-image ,filename) ,filename)))
```

2. Evaluate in emacs: `(setq sly-enable-evaluate-in-emacs t)`
3. Evaluate in the sly buffer: `(display-image-on-disk "/tmp/example.jpg")`

It is totally usable already, but it can be better. Please take a look at the function `sly-dispatch-media-event` (currently commented out). In particular, I wonder how slynk triggers an automatic event, which under the macro`sly-dcase` has car `:write-image`. If someone could let me know, I'm happy to integrate it into this contrib.

Any comment is welcome!
