### PR TITLE
Add option to replace SLIME on load w/o prompting

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -7475,11 +7475,25 @@ can be found."
 ;;;###autoload
 (add-hook 'lisp-mode-hook 'sly-editing-mode)
 
+(defcustom sly-replace-slime 'ask
+  "Specify whether SLY should replace SLIME at load time.
+
+This only has an effect if parts of SLIME components are already
+loaded (e.g. in `lisp-mode-hook').
+
+If `ask' prompt the user at load-time; if nil never replace; if t or
+other non-nil value to unconditionally replace SLIME."
+  :type '(choice (const :tag "Ask user" ask)
+                 (const :tag "Do not replace SLIME" nil)
+                 (const :tag "Do replace SLIME" t)))
+
 (cond
  ((or (not (memq 'slime-lisp-mode-hook lisp-mode-hook))
       noninteractive
       (prog1
-          (y-or-n-p "[sly] SLIME detected in `lisp-mode-hook', causes keybinding conflicts.  Remove it for this Emacs session?")
+          (if (eq sly-replace-slime 'ask)
+              (y-or-n-p "[sly] SLIME detected in `lisp-mode-hook', causes keybinding conflicts.  Remove it for this Emacs session?")
+            sly-replace-slime)
         (warn "To restore SLIME in this session, customize `lisp-mode-hook'
 and replace `sly-editing-mode' with `slime-lisp-mode-hook'.")))
   (remove-hook 'lisp-mode-hook 'slime-lisp-mode-hook)


### PR DESCRIPTION
Currently, SLY interactively prompts the user at load time if SLIME already loaded, to ask whether to replace SLIME in `lisp-mode-hook`.  This change offers a new flag, `sly-ask-replace-slime`, to control the prompting behavior.  It defaults to `t`, which preserves the current behavior.  But if you put `(setq sly-ask-replace-slime nil)` in your Emacs initialization before loading SLY, then if SLY finds that SLIME is already loaded, SLY will just replace it without prompting.

Motivation:

Someone might have SLIME automatically loaded in some environments, SLY in others, and both in still others.  For example, I have this in my .emacs file:

```elisp
(setq sly-ask-replace-slime nil)  ;; this line is new -- assumes this PR
(dolist (lib (list "slime" "sly"))
  (let ((lib-path (expand-file-name (format "~/src/%s/%s.el" lib lib))))
    (add-to-list 'load-path (expand-file-name (format "~/src/%s" lib)))
    (require (intern lib))))
```

In environments where the SLIME source is checked out, SLIME will be loaded first; in environments where the SLIME source is not available, SLIME will not be loaded (and this is not an error).  Same with SLY: in some environments it may be present, and in others not.  When SLY is present, I always want to prefer it, and I don't want to be prompted about this at startup time.