### PR TITLE
Revamp loop indentation

### DIFF
--- a/lib/sly-cl-indent.el
+++ b/lib/sly-cl-indent.el
@@ -1414,57 +1414,6 @@ environment\\|more\
           "\\_>")
   "Regexp matching loop macro keywords which introduce body forms.")
 
-;; Not currently used
-(defvar sly--common-lisp-accumulation-loop-macro-keyword
-  (concat "\\(?:\\_<\\|#?:\\)"
-          (regexp-opt '("collect" "collecting"
-                        "append" "appending"
-                        "nconc" "nconcing"
-                        "sum" "summing"
-                        "count" "counting"
-                        "maximize" "maximizing"
-                        "minimize" "minimizing"))
-          "\\_>")
-  "Regexp matching loop macro keywords which introduce accumulation clauses.")
-
-;; This is so "and when" and "else when" get handled right
-;; (not to mention "else do" !!!)
-(defvar sly--common-lisp-prefix-loop-macro-keyword
-  (concat "\\(?:\\_<\\|#?:\\)" (regexp-opt '("and" "else")) "\\_>")
-  "Regexp matching loop macro keywords which are prefixes.")
-
-(defvar sly--common-lisp-indent-clause-joining-loop-macro-keyword
-  "\\(?:\\_<\\|#?:\\)and\\_>"
-  "Regexp matching 'and', and anything else there ever comes to be like it.")
-
-(defvar sly--common-lisp-indent-indented-loop-macro-keyword
-  (concat "\\(?:\\_<\\|#?:\\)"
-          (regexp-opt '("upfrom" "downfrom" "upto" "downto" "below" "above"
-                        "into" "in" "on" "by" "from" "to" "by" "across" "being"
-                        "each" "the" "then" "hash-key" "hash-keys" "hash-value"
-                        "hash-values" "present-symbol" "present-symbols"
-                        "external-symbol" "external-symbols" "using" "symbol"
-                        "symbols" "float" "fixnum" "t" "nil" "of-type" "of" "="))
-          "\\_>")
-  "Regexp matching keywords introducing loop subclauses.
-Always indented two.")
-
-(defvar sly--common-lisp-indenting-loop-macro-keyword
-  (concat "\\(?:\\_<\\|#?:\\)" (regexp-opt '("when" "unless" "if")) "\\_>")
-  "Regexp matching keywords introducing conditional clauses.
-Cause subsequent clauses to be indented.")
-
-(defvar sly--common-lisp-dedendenting-loop-macro-keyword
-  (concat "\\(?:\\_<\\|#?:\\)" (regexp-opt '("else" "end")) "\\_>")
-  "Regexp matching keywords concluding conditional clauses.
-Cause current and subsequent clauses to be dedented.")
-
-(defvar sly--lisp-indent-loop-macro-else-keyword
-  "\\(?:\\_<\\|#?:\\)else\\_>")
-
-(defvar sly--lisp-indent-loop-macro-end-keyword
-  "\\(?:\\_<\\|#?:\\)end\\_>")
-
 ;;; Attempt to indent the loop macro ...
 (defun sly--lisp-indent-loop-part-indentation (indent-point state type)
   "Compute the indentation of loop form constituents."
@@ -1512,131 +1461,314 @@ Cause current and subsequent clauses to be dedented.")
   (unless (eolp)
     (current-column)))
 
+(defun sly--lisp-indent-loop-macro-partial-parse (parse-state indent-point)
+  "Return an alist of the forms and their positions in the current loop.
+Only parse the loop until the line following INDENT-POINT."
+  (save-excursion
+    (goto-char (sly--lisp-indent-parse-state-start parse-state))
+    (forward-symbol 1)
+    (let ((compound-form-regexp
+           (rx (* (or "`" "'" "#'"
+                      ;; This technically fails with ,#() but I don't
+                      ;; care to fix it.  I don't want to limit it to
+                      ;; the default options of `@' and `.' because of
+                      ;; my cl-extended-comma library.
+                      (: "," (? (syntax symbol)))
+                      (: "#" (+ digit) "=")
+                      (: "#" (or "+" "-")) ; #. is in general not possible to evaluate
+                      )
+                  (* space))
+               (group "(")))
+          forms)
+      (catch 'loop-parse
+        (while (and (< (pos-bol) indent-point)
+                    (not (eobp)))
+          (let* ((form-beginning (progn (skip-syntax-forward "->") (point)))
+                 (form-type
+                  (cond
+                   ((looking-at-p (rx (syntax comment-start))) 'comment)
+                   ((looking-at (rx "#" (+ digit) "#"))
+                    (save-excursion
+                      (when (re-search-backward
+                             (rx "#" (literal (match-string 1)) "=")
+                             (nth 9 parse-state) t)
+                        (if (looking-at compound-form-regexp) 'compound 'atomic))))
+                   (t (if (looking-at compound-form-regexp) 'compound 'atomic))))
+                 (form-end
+                  (if (eq form-type 'comment)
+                      (progn (skip-syntax-forward "^>")
+                             (point))
+                    (condition-case e
+                        (scan-sexps (if (eq form-type 'compound) (match-beginning 1) (point)) 1)
+                      (scan-error
+                       (unless (> (point) indent-point)
+                         (apply 'signal e)))))))
+            ;; If form-end is null then we must have no more sexps remaining
+            (when (null form-end)
+              (throw 'loop-parse nil))
+            (push (cons form-beginning
+                        (when (eq form-type 'atomic)
+                          (buffer-substring-no-properties form-beginning form-end)))
+                  forms)
+            (goto-char form-end))))
+      (nreverse forms))))
+
+(defvar sly--lisp-indent-loop-macro-allowed-bodies-alist
+  (let* ((anything t)
+         (compound-form nil)
+         (type-spec '(| '(fixnum float t nil) of-type))
+         (selectable-clause
+          '(| do doing return if when unless
+              collect collecting append appending nconc nconcing
+              count counting sum summing maximize maximizing minimize minimizing)))
+    `((with #1=(: 4 ,anything [,type-spec] 2 [=]) 0 (* ('and &droppable #1#)))
+      ((initially finally do doing) 2 (&inline ,compound-form &droppable (* ,compound-form)))
+      (return 2 ,anything)
+      ((collect collecting append appending nconc nconcing) 2 ,anything [into])
+      ((count counting sum summing maximize maximizing minimize minimizing) 2 ,anything [into] [,type-spec])
+      ((if when unless) 4 ,anything 2 (,selectable-clause (* ('and &droppable 2 ,selectable-clause))) 0 [else] ['end])
+      (else 2 (&inline ,selectable-clause (* ('and &droppable 2 ,selectable-clause))))
+      ((while until repeat always never thereis) 2 ,anything)
+      ((for as) 4 ,anything [,type-spec] 2
+       (| (#2='(from upfrom downfrom to upto downto below above by) (* #2#))
+          (: (| in on) [by])
+          (: = [then])
+          across
+          (: ('being &droppable '(the each)
+                     '( hash-key  hash-value  symbol  present-symbol  external-symbol
+                        hash-keys hash-values symbols present-symbols external-symbols))
+             [(| in of)] [using])))
+      ;; Various one-object subclauses
+      ((= of-type
+          into                          ; Accumulation
+          from upfrom downfrom to upto downto below above ; Arithmetic for-as
+          in on by then across of using ; Miscellaneous for-as
+          )
+       2 ,anything)))
+  "Alist of specs controlling the indentation of LOOP.
+
+Each key is a symbol or a list of symbols, and the value is the contents
+of an implicit droppable body spec.  Each list is of the form (SYMBOLS
+BODY...) and is the equivalent of the spec ('SYMBOLS &droppable BODY...)
+
+A spec object describes how to move forward on an alist of position and
+objects, of the form ((POS . OBJ)...).  OBJ is either nil, corresponding
+to a compound form or comment, or a string containing the written
+representation of some atom.
+
+Some terminology:
+- Each cons cell (POS . OBJ) is referred to as a `form'.
+- The alist ((POS . OBJ)...) is referred to as the `list of forms'.
+- \"Moving forward [by N]\" a list of forms is the equivalent of taking
+  its `nthcdr' by N.
+- When SPEC \"matches [the first N elements]\" of a list of forms,
+  \"moving forward [by SPEC]\" is the equivalent of moving forward by N.
+
+The defined specs are:
+- Anything match: t, `anything' :: Match the first form, regardless of
+  what it is.
+
+- Compound form match: nil, `compound-form' :: Match the first form if
+  it is a compound form or a comment.
+
+- Symbol match: '{SYMBOL | (SYMBOL...)} :: Match the first form if it is
+  a symbol whose name, without the package name, is case-insensitively
+  contained in SYMBOLs.
+
+- Alternation: (| SPEC...) :: Match with the first SPEC which matches.
+
+- Optional match: [SPEC...] :: Move forward by SPECs in order, otherwise
+  match nothing and proceed.  This is equivalent to (: &droppable (:
+  SPEC...)).
+
+- Greedy match: (* SPEC...) :: Move forward by SPECs as though they were
+  in a sequence spec in order repeatedly until it fails.  Match whatever
+  was matched until the failed run of SPECs.
+
+- Sequence match: (: {SPEC | integer | &droppable}...)
+  Match all SPECs in order, each one matching the result of the previous
+  one.  If an integer is present, set the offset relative to the body of
+  all following SPECs to that.  If a SPEC fails to match before
+  &droppable, the sequence spec does not match, otherwise it goes
+  forward until a SPEC fails or all SPECs match.
+
+- Body match: ([&inline] SPEC MORE-SPECS...) :: Establish a body for
+  MORE-SPECS according to SPEC.  If the first item is &inline, then the
+  body starts at the beginning of the next form, otherwise it starts at
+  the beginning of the first symbol at the same line as the next form.
+  MORE-SPECS are interpreted as an implicit sequence match.
+
+- Spec match: SYMBOL :: Match the spec corresponding to SYMBOL.  If
+  SYMBOL is internal, establish a body at the same column as the
+  beginning of SYMBOL, otherwise establish a body at the same column as
+  the beginning of the first symbol in the line SYMBOL is at.")
+
 (defun sly--lisp-indent-loop-macro-1 (parse-state indent-point)
-  (catch 'return-indentation
-    (save-excursion
-      ;; Find first clause of loop macro, and use it to establish
-      ;; base column for indentation
-      (goto-char (sly--lisp-indent-parse-state-start parse-state))
-      (let ((loop-start-column (current-column)))
-        (sly--lisp-indent-loop-advance-past-keyword-on-line)
+  (let* ((forms (th/sly--lisp-indent-loop-macro-partial-parse parse-state indent-point))
+         (loop-start-column
+          (save-excursion
+            (goto-char (sly--lisp-indent-parse-state-start parse-state))
+            (current-column)))
+         (loop-body-start-column
+          (save-excursion
+            (goto-char (sly--lisp-indent-parse-state-start parse-state))
+            (forward-symbol 1)
+            (skip-syntax-forward "->")
+            (current-column)))
+         (real-indent-point
+          (save-excursion (goto-char indent-point)
+                          (back-to-indentation)
+                          (point))))
+    (catch 'return-indentation
+      (cl-macrolet
+          ((form-beg     (form) `(car ,form))
+           (form-content (form) `(cdr ,form)))
+        (cl-labels
+            ((settable-symbol-p (obj)
+               (and (symbolp obj)
+                    (not (keywordp obj))
+                    (not (eq obj t))
+                    (not (eq obj nil))))
+             (symbol-internedp (symbol)
+               (or (eq symbol nil)
+                   (intern-soft symbol)))
+             (ensure-string (string-designator &key trim-package)
+               (if trim-package
+                   (string-trim-left (ensure-string string-designator)
+                                     (rx (or "" "#" "cl" "common-lisp") ":"))
+                 (cl-typecase string-designator
+                   (string string-designator)
+                   (symbol
+                    (if (symbol-internedp string-designator)
+                        (symbol-name string-designator)
+                      (concat "#:" (symbol-name string-designator)))))))
+             (symbol-match-p (symbol form)
+               (string-equal-ignore-case (ensure-string (form-content form) :trim-package t)
+                                         (ensure-string symbol)))
+             (symbol-spec (symbol)
+               (cdr
+                (cl-assoc (ensure-string symbol)
+                          sly--lisp-indent-loop-macro-allowed-bodies-alist
+                          :key (lambda (matching-symbols)
+                                 (mapcar #'ensure-string (ensure-list matching-symbols)))
+                          :test 'member-ignore-case)))
 
-        (when (eolp)
-          (forward-line 1)
-          (end-of-line)
-          ;; If indenting first line after "(loop <newline>"
-          ;; cop out ...
-          (if (<= indent-point (point))
-              (throw 'return-indentation
-                     (+ loop-start-column
-                        sly-lisp-loop-clauses-indentation)))
-          (back-to-indentation))
-
-        (let* ((case-fold-search t)
-               (loop-macro-first-clause (point))
-               (previous-expression-start
-                (sly--lisp-indent-parse-state-prev parse-state))
-               (default-value (current-column))
-               (loop-body-p nil)
-               (loop-body-indentation nil)
-               (indented-clause-indentation (+ 2 default-value)))
-          ;; Determine context of this loop clause, starting with the
-          ;; expression immediately preceding the line we're trying to indent
-          (goto-char previous-expression-start)
-
-          ;; Handle a body-introducing-clause which ends a line specially.
-          (if (looking-at sly--common-lisp-body-introducing-loop-macro-keyword)
-              (let ((keyword-position (current-column)))
-                (setq loop-body-p t)
-                (setq loop-body-indentation
-                      (if (sly--lisp-indent-loop-advance-past-keyword-on-line)
-                          (current-column)
-                        (back-to-indentation)
-                        (if (/= (current-column) keyword-position)
-                            (+ 2 (current-column))
-                          (+ sly-lisp-loop-body-forms-indentation
-                             (if sly-lisp-loop-indent-body-forms-relative-to-loop-start
-                                 loop-start-column
-                               keyword-position))))))
-
-            (back-to-indentation)
-            (if (< (point) loop-macro-first-clause)
-                (goto-char loop-macro-first-clause))
-            ;; If there's an "and" or "else," advance over it.
-            ;; If it is alone on the line, the next "cond" will treat it
-            ;; as if there were a "when" and indent under it ...
-            (let ((exit nil))
-              (while (and (null exit)
-                          (looking-at sly--common-lisp-prefix-loop-macro-keyword))
-                (if (null (sly--lisp-indent-loop-advance-past-keyword-on-line))
-                    (progn (setq exit t)
-                           (back-to-indentation)))))
-
-            ;; Found start of loop clause preceding the one we're
-            ;; trying to indent. Glean context ...
-            (cond
-             ((looking-at "(")
-              ;; We're in the middle of a clause body ...
-              (setq loop-body-p t)
-              (setq loop-body-indentation (current-column)))
-             ((looking-at sly--common-lisp-body-introducing-loop-macro-keyword)
-              (setq loop-body-p t)
-              ;; Know there's something else on the line (or would
-              ;; have been caught above)
-              (sly--lisp-indent-loop-advance-past-keyword-on-line)
-              (setq loop-body-indentation (current-column)))
-             (t
-              (setq loop-body-p nil)
-              (if (or (looking-at sly--common-lisp-indenting-loop-macro-keyword)
-                      (looking-at sly--common-lisp-prefix-loop-macro-keyword))
-                  (setq default-value (+ 2 (current-column))))
-              (setq indented-clause-indentation (+ 2 (current-column)))
-              ;; We still need loop-body-indentation for "syntax errors" ...
-              (goto-char previous-expression-start)
-              (setq loop-body-indentation (current-column)))))
-
-          ;; Go to first non-blank character of the line we're trying
-          ;; to indent. (if none, wind up poised on the new-line ...)
-          (goto-char indent-point)
-          (back-to-indentation)
-          (cond
-           ((looking-at "(")
-            ;; Clause body ...
-            loop-body-indentation)
-           ((or (eolp) (looking-at ";"))
-            ;; Blank line.  If body-p, indent as body, else indent as
-            ;; vanilla clause.
-            (if loop-body-p
-                loop-body-indentation
-              (or (and (looking-at ";") (sly--lisp-indent-trailing-comment))
-                  default-value)))
-           ((looking-at sly--common-lisp-indent-indented-loop-macro-keyword)
-            indented-clause-indentation)
-           ((or (looking-at sly--common-lisp-indent-clause-joining-loop-macro-keyword)
-                (looking-at sly--common-lisp-dedendenting-loop-macro-keyword))
-            (let ((conditionalp
-                   (not (looking-at-p sly--common-lisp-indent-clause-joining-loop-macro-keyword)))
-                  (conditional-nesting 1)
-                  (stolen-indent-column nil))
-              (forward-line -1)
-              (while (and (null stolen-indent-column)
-                          (> (point) loop-macro-first-clause))
-                (back-to-indentation)
-                (if (and (< (current-column) loop-body-indentation)
-                         (looking-at "\\(#?:\\)?\\sw"))
-                    (progn
-                      (when (looking-at sly--common-lisp-dedendenting-loop-macro-keyword)
-                        (cl-incf conditional-nesting)
-                        (when (or (looking-at sly--lisp-indent-loop-macro-else-keyword))
-                          (sly--lisp-indent-loop-advance-past-keyword-on-line)))
-                      (if (or (not conditionalp)
-                              (and (looking-at sly--common-lisp-indenting-loop-macro-keyword)
-                                   (zerop (cl-decf conditional-nesting))))
-                          (setq stolen-indent-column (current-column))
-                        (forward-line -1)))
-                  (forward-line -1)))
-              (or stolen-indent-column default-value)))
-           (t default-value)))))))
+             ;; `forms' is a list with a terminating t instead of nil
+             (consume-forms (forms spec body-beg &optional (offset 0))
+               ;; (message "consume-forms: %S %S %S %S" forms spec body-beg offset)
+               (if (eq forms t) t
+                 (setq forms
+                       (catch 'mismatch
+                         (pcase spec
+                           ;; Anything
+                           ('t (cdr forms))
+                           ;; Compound-only
+                           ('nil (when (null (form-content (car forms)))
+                                   (cdr forms)))
+                           ;; Symbol match
+                           (`',(or (and (pred ensure-string)
+                                        (app list symbols))
+                                   (and (pred listp)
+                                        (pred (lambda (symbols)
+                                                (cl-every #'ensure-string symbols)))
+                                        symbols))
+                            (when (cl-some (lambda (symbol)
+                                             (symbol-match-p symbol (car forms)))
+                                           symbols)
+                              (cdr forms)))
+                           ;; Alternation
+                           (`(| . ,specs)
+                            ;; Split the specs into those which need to
+                            ;; be checked by `consume-forms' directly
+                            ;; and those we can optimize (i.e. symbol
+                            ;; specs which we can look up directly)
+                            (let ((symbol-specs (cl-remove-if-not #'settable-symbol-p specs))
+                                  (complex-specs (cl-remove-if #'settable-symbol-p specs)))
+                              (or (and-let* ((symbol (ensure-string (form-content (car forms))
+                                                                    :trim-package t))
+                                             ((cl-member symbol symbol-specs
+                                                         :key #'ensure-string
+                                                         :test 'string-equal-ignore-case))
+                                             ((symbol-spec symbol)))
+                                    (consume-forms forms symbol body-beg offset))
+                                  (cl-some (lambda (body)
+                                             (consume-forms forms body body-beg offset))
+                                           complex-specs))))
+                           ;; Optional match
+                           ((and (pred vectorp)
+                                 (app (lambda (vector) (seq-into vector 'list))
+                                      specs))
+                            (or (consume-forms forms `(: ,@specs) body-beg offset)
+                                forms))
+                           ;; Greedy match
+                           (`(* . ,specs)
+                            (while-let (((not (eq forms t)))
+                                        (remaining-forms (consume-forms forms `(: ,@specs) body-beg offset)))
+                              (when (equal forms remaining-forms)
+                                (error "Encountered empty greedy match %S when parsing %S"
+                                       spec forms))
+                              (setq forms remaining-forms))
+                            forms)
+                           ;; Sequential match
+                           (`(: . ,specs)
+                            (let ((requiredp t))
+                              (cl-reduce
+                               (lambda (forms extended-spec)
+                                 (pcase extended-spec
+                                   ((guard (eq forms t))
+                                    ;; (message "throw (:) 'return-indentation: %S %S" body-beg offset)
+                                    (throw 'return-indentation (+ offset body-beg)))
+                                   ((and (pred integerp)
+                                         new-offset)
+                                    (setq offset new-offset)
+                                    forms)
+                                   ('&droppable
+                                    (setq requiredp nil)
+                                    forms)
+                                   (subspec
+                                    (or (consume-forms forms subspec body-beg offset)
+                                        (throw 'mismatch (unless requiredp forms))))))
+                               specs :initial-value forms)))
+                           ;; Body match
+                           ((and (pred proper-list-p)
+                                 (or (and `(&inline ,head-spec . ,specs)
+                                          (let inlinep t))
+                                     (and `(,head-spec . ,specs)
+                                          (let inlinep nil))))
+                            (consume-forms
+                             (or (consume-forms forms head-spec body-beg offset)
+                                 (throw 'mismatch nil))
+                             `(: ,@specs)
+                             (save-excursion
+                               (goto-char (form-beg (car forms)))
+                               (unless inlinep (back-to-indentation))
+                               (current-column))))
+                           ;; Spec match
+                           ((and (app ensure-string (and (pred identity) symbol))
+                                 (app symbol-spec (and (pred identity) spec)))
+                            (consume-forms forms `(',symbol ,@spec) body-beg offset))
+                           (_ (error "Bad spec %S" spec)))))
+                 (unless (null forms)
+                   (if (or (eq forms t)
+                           (< real-indent-point (form-beg (car forms))))
+                       (progn
+                         ;; (message "throw (endp) 'return-indentation: %S %S %S %S" forms spec body-beg offset)
+                         (throw 'return-indentation (+ offset body-beg)))
+                     ;; (message "=> %S" forms)
+                     forms)))))
+          ;; End `forms' with t instead of nil so that we can return nil
+          ;; for mismatches
+          (setcdr (last forms) t)
+          (or (consume-forms
+               forms
+               (let* ((anything t)
+                      (single-clause
+                       `(| ,@(mapcan (lambda (spec) (copy-sequence (ensure-list (car spec))))
+                                     sly--lisp-indent-loop-macro-allowed-bodies-alist)
+                           ,anything)))
+                 `(&inline ,single-clause (* ,single-clause)))
+               loop-start-column sly-lisp-loop-clauses-indentation)
+              loop-body-start-column))))))
 
 (defalias 'sly--lisp-indent-if*-advance-past-keyword-on-line
   #'sly--lisp-indent-loop-advance-past-keyword-on-line)

--- a/test/sly-cl-indent-test.txt
+++ b/test/sly-cl-indent-test.txt
@@ -141,6 +141,27 @@
                               (body filled to comment))
 
 ;;; Test: indent-12
+;;
+;; sly-lisp-loop-indent-subclauses: t
+
+(loop for x below 3
+      if foo
+        unless bar
+          collect (fubar)
+          and do (moo)
+          and
+            if (not t)
+              do (nothing)
+            end
+        else
+          do (some more work)
+          and do (even more work)
+          and
+            if some-condition
+              do (unnecessary amount more work)
+            else do (necessary amount more work ??))
+
+;;; Test: indent-13
 
 (defun foo (x)
   (tagbody
@@ -170,7 +191,7 @@
               (lose
                3))))))
 
-;;; Test: indent-13
+;;; Test: indent-14
 
 (if* (eq t nil)
    then ()
@@ -180,12 +201,12 @@ thenret x
    else (balbkj)
         (sdf))
 
-;;; Test: indent-14
+;;; Test: indent-15
 
 (list foo #+foo (foo)
           #-foo (no-foo))
 
-;;; Test: indent-15
+;;; Test: indent-16
 ;;
 ;; sly-lisp-loop-indent-subclauses: t
 
@@ -193,7 +214,7 @@ thenret x
       for y in quux1
       )
 
-;;; Test: indent-16
+;;; Test: indent-17
 ;;
 ;; sly-lisp-loop-indent-subclauses: nil
 
@@ -201,7 +222,7 @@ thenret x
       for y in quux1
       )
 
-;;; Test: indent-17
+;;; Test: indent-18
 ;;
 ;; sly-lisp-loop-indent-subclauses: nil
 ;; sly-lisp-loop-indent-forms-like-keywords: t
@@ -218,26 +239,9 @@ thenret x
       (print y)
       (print 'ok!))
 
-;;; Test: indent-18
-;;
-;; sly-lisp-loop-indent-subclauses: nil
-;; sly-lisp-loop-indent-forms-like-keywords: nil
-
-(loop for x in foo
-      for y in quux
-      initially
-         (princ "hi!")
-      finally (foo)
-              (fo)
-              (zoo)
-      do
-         (print x)
-         (print y)
-         (print 'ok!))
-
 ;;; Test: indent-19
 ;;
-;; sly-lisp-loop-indent-subclauses: t
+;; sly-lisp-loop-indent-subclauses: nil
 ;; sly-lisp-loop-indent-forms-like-keywords: nil
 
 (loop for x in foo
@@ -254,6 +258,23 @@ thenret x
 
 ;;; Test: indent-20
 ;;
+;; sly-lisp-loop-indent-subclauses: t
+;; sly-lisp-loop-indent-forms-like-keywords: nil
+
+(loop for x in foo
+      for y in quux
+      initially
+         (princ "hi!")
+      finally (foo)
+              (fo)
+              (zoo)
+      do
+         (print x)
+         (print y)
+         (print 'ok!))
+
+;;; Test: indent-21
+;;
 ;; sly-lisp-loop-indent-subclauses: nil
 ;; sly-lisp-loop-indent-forms-like-keywords: nil
 
@@ -263,7 +284,7 @@ thenret x
       do (foo) (bar)
          (quux))
 
-;;; Test: indent-21
+;;; Test: indent-22
 ;;
 ;; sly-lisp-loop-indent-subclauses: t
 
@@ -273,18 +294,18 @@ thenret x
       do (foo) (bar)
          (quux))
 
-;;; Test: indent-22
+;;; Test: indent-23
 
 (defsetf foo bar
   "the doc string")
 
-;;; Test: indent-23
+;;; Test: indent-24
 
 (defsetf foo
     bar
   "the doc string")
 
-;;; Test: indent-24
+;;; Test: indent-25
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 
@@ -293,21 +314,21 @@ thenret x
     (a b c)
   stuff)
 
-;;; Test: indent-25
+;;; Test: indent-26
 ;;
 ;; sly-lisp-align-keywords-in-calls: t
 
 (make-instance 'foo :bar t :quux t
                     :zot t)
 
-;;; Test: indent-26
+;;; Test: indent-27
 ;;
 ;; sly-lisp-align-keywords-in-calls: nil
 
 (make-instance 'foo :bar t :quux t
                :zot t)
 
-;;; Test: indent-27
+;;; Test: indent-28
 ;;
 ;; sly-lisp-lambda-list-indentation: nil
 
@@ -318,7 +339,7 @@ thenret x
                 k3 k4)
   'hello)
 
-;;; Test: indent-28
+;;; Test: indent-29
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -330,7 +351,7 @@ thenret x
     foo
   body)
 
-;;; Test: indent-29
+;;; Test: indent-30
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -341,19 +362,19 @@ thenret x
        &rest more)
   body)
 
-;;; Test: indent-30
+;;; Test: indent-31
 
 (foo fii
      (or x
          y) t
      bar)
 
-;;; Test: indent-31
+;;; Test: indent-32
 
 (foo
  (bar))
 
-;;; Test: indent-32
+;;; Test: indent-33
 ;;
 ;; comment-indent-function: (lambda () nil)
 ;; comment-column: nil
@@ -368,7 +389,7 @@ thenret x
          (
           quux))
 
-;;; Test: indent-33
+;;; Test: indent-34
 
 (complex-indent.1 ((x z
                     f
@@ -384,7 +405,7 @@ thenret x
   (bodyform)
   (another))
 
-;;; Test: indent-34
+;;; Test: indent-35
 
 (complex-indent.2 (bar quux
                        zot)
@@ -393,7 +414,7 @@ thenret x
   (form1)
   (form2))
 
-;;; Test: indent-35
+;;; Test: indent-36
 
 (complex-indent.3 (:wait fii
                          (this is
@@ -401,7 +422,7 @@ thenret x
   (bodyform)
   (another))
 
-;;; Test: indent-36
+;;; Test: indent-37
 
 (defmacro foo (body)
   `(let (,@(stuff)
@@ -410,14 +431,14 @@ thenret x
          (foo foo))
      ,@bofy))
 
-;;; Test: indent-37
+;;; Test: indent-38
 
 (defun foo ()
   `(list foo bar
          ,@(quux fo
                  foo)))
 
-;;; Test: indent-38
+;;; Test: indent-39
 
 (defmacro foofoo (body)
   `(foo
@@ -427,7 +448,7 @@ thenret x
            (foo foo))
        ,@bofy)))
 
-;;; Test: indent-39
+;;; Test: indent-40
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -441,7 +462,7 @@ thenret x
   zot
   fii)
 
-;;; Test: indent-40
+;;; Test: indent-41
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -450,7 +471,7 @@ thenret x
                                  y)
   (list zot))
 
-;;; Test: indent-41
+;;; Test: indent-42
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -460,7 +481,7 @@ thenret x
                                    y)
     (list fii)))
 
-;;; Test: indent-42
+;;; Test: indent-43
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -472,7 +493,7 @@ thenret x
                                     y)
       (list a b x y))))
 
-;;; Test: indent-43
+;;; Test: indent-44
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -482,7 +503,7 @@ thenret x
                           b)
     (list x y a b)))
 
-;;; Test: indent-44
+;;; Test: indent-45
 
 (let (definer
       foo
@@ -490,7 +511,7 @@ thenret x
       quux)
   ...)
 
-;;; Test: indent-45
+;;; Test: indent-46
 
 (let (definition
       foo
@@ -498,20 +519,20 @@ thenret x
       quux)
   ...)
 
-;;; Test: indent-46
+;;; Test: indent-47
 
 (let (foo bar
       quux)
   ...)
 
-;;; Test: indent-47
+;;; Test: indent-48
 
 (with-compilation-unit
     (:foo t
      :quux nil)
   ...)
 
-;;; Test: indent-48
+;;; Test: indent-49
 
 (cond
   ((> x y) (foo)
@@ -527,7 +548,7 @@ thenret x
   (t (foo)
      (bar)))
 
-;;; Test: indent-49
+;;; Test: indent-50
 
 (cond ((> x y) (foo)
        ;; This isn't ideal -- I at least would align with (FOO here.
@@ -539,25 +560,13 @@ thenret x
       (t (foo)
          (bar)))
 
-;;; Test: indent-50
+;;; Test: indent-51
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: nil
 ;; sly-lisp-lambda-list-keyword-alignment: nil
 
 (defun foo (x &optional opt1
                 opt2
-            &rest rest
-            &allow-other-keys)
-  (list opt1 opt2
-        rest))
-
-;;; Test: indent-51
-;;
-;; sly-lisp-lambda-list-keyword-parameter-alignment: t
-;; sly-lisp-lambda-list-keyword-alignment: nil
-
-(defun foo (x &optional opt1
-                        opt2
             &rest rest
             &allow-other-keys)
   (list opt1 opt2
@@ -565,6 +574,18 @@ thenret x
 
 ;;; Test: indent-52
 ;;
+;; sly-lisp-lambda-list-keyword-parameter-alignment: t
+;; sly-lisp-lambda-list-keyword-alignment: nil
+
+(defun foo (x &optional opt1
+                        opt2
+            &rest rest
+            &allow-other-keys)
+  (list opt1 opt2
+        rest))
+
+;;; Test: indent-53
+;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: nil
 ;; sly-lisp-lambda-list-keyword-alignment: t
 
@@ -575,7 +596,7 @@ thenret x
   (list opt1 opt2
         rest))
 
-;;; Test: indent-53
+;;; Test: indent-54
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -587,7 +608,7 @@ thenret x
   (list opt1 opt2
         rest))
 
-;;; Test: indent-54
+;;; Test: indent-55
 ;;
 
 (loop (foo)
@@ -595,31 +616,31 @@ thenret x
       (bar)
       (quux))
 
-;;; Test: indent-55
+;;; Test: indent-56
 ;;
 
 (loop ;; comment
       (foo)
       (bar))
 
-;;; Test: indent-56
-;;
-
-(loop
-  (foo)
-  ;; comment
-  (bar))
-
-
 ;;; Test: indent-57
 ;;
 
 (loop
+  (foo)
+  ;; comment
+  (bar))
+
+
+;;; Test: indent-58
+;;
+
+(loop
   ;; comment
   (foo)
   (bar))
 
-;;; Test: indent-58
+;;; Test: indent-59
 ;;
 ;; sly-lisp-loop-indent-subclauses: t
 
@@ -628,7 +649,7 @@ thenret x
       do (foo foo)
          (foo))
 
-;;; Test: indent-59
+;;; Test: indent-60
 ;;
 ;; sly-lisp-loop-indent-subclauses: nil
 
@@ -637,7 +658,7 @@ thenret x
       do (foo foo)
          (foo))
 
-;;; Test: indent-60
+;;; Test: indent-61
 ;;
 ;; sly-lisp-loop-indent-subclauses: t
 ;; sly-indentation--test-function: indent-region
@@ -647,7 +668,7 @@ thenret x
   with foo = t
   do (foo foo))
 
-;;; Test: indent-61
+;;; Test: indent-62
 ;;
 ;; sly-lisp-loop-indent-subclauses: nil
 
@@ -657,7 +678,7 @@ thenret x
   do (foo foo)
      (foo))
 
-;;; Test: indent-62
+;;; Test: indent-63
 ;;
 ;; sly-lisp-loop-indent-subclauses: t
 
@@ -666,7 +687,7 @@ thenret x
          ;; comment inside clause
          (bar))
 
-;;; Test: indent-63
+;;; Test: indent-64
 ;;
 ;; sly-lisp-loop-indent-subclauses: nil
 
@@ -676,7 +697,7 @@ thenret x
          (bar))
 
 
-;;; Test: indent-64
+;;; Test: indent-65
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -685,7 +706,7 @@ thenret x
                                         y)
   (list zot))
 
-;;; Test: indent-65
+;;; Test: indent-66
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -694,7 +715,7 @@ thenret x
     :around (zot &key x y)
   (list zot))
 
-;;; Test: indent-66
+;;; Test: indent-67
 ;;
 
 (define-condition
@@ -704,7 +725,7 @@ thenret x
   ()
   (:report "foo"))
 
-;;; Test: indent-67
+;;; Test: indent-68
 ;;
 
 (defclass
@@ -715,24 +736,10 @@ thenret x
   (:metaclass foo-class))
 
 
-;;; Test: indent-68
+;;; Test: indent-69
 ;;
 ;; sly-lisp-loop-indent-subclauses: nil
 ;; sly-indentation--test-function: indent-region
-
-(progn
-  (loop
-    repeat 1000
-    do ;; This is the
-       ;; beginning
-       (foo))
-  (loop repeat 100 ;; This too
-                   ;; is a beginning
-        do (foo)))
-
-;;; Test: indent-69
-;;
-;; sly-lisp-loop-indent-subclauses: t
 
 (progn
   (loop
@@ -746,6 +753,20 @@ thenret x
 
 ;;; Test: indent-70
 ;;
+;; sly-lisp-loop-indent-subclauses: t
+
+(progn
+  (loop
+    repeat 1000
+    do ;; This is the
+       ;; beginning
+       (foo))
+  (loop repeat 100 ;; This too
+                   ;; is a beginning
+        do (foo)))
+
+;;; Test: indent-71
+;;
 ;; sly-lisp-loop-indent-subclauses: nil
 
 (progn
@@ -758,7 +779,7 @@ thenret x
                      ;; is a beginning
         :do (foo)))
 
-;;; Test: indent-71
+;;; Test: indent-72
 ;;
 ;; sly-lisp-loop-indent-subclauses: t
 
@@ -772,25 +793,13 @@ thenret x
                     ;; is a beginning
         #:do (foo)))
 
-;;; Test: indent-72
+;;; Test: indent-73
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: nil
 ;; sly-lisp-lambda-list-keyword-alignment: nil
 
 (flet ((foo (foo &optional opt1
                    opt2
-             &rest rest)
-         (list foo opt1 opt2
-               rest)))
-  ...)
-
-;;; Test: indent-73
-;;
-;; sly-lisp-lambda-list-keyword-parameter-alignment: t
-;; sly-lisp-lambda-list-keyword-alignment: nil
-
-(flet ((foo (foo &optional opt1
-                           opt2
              &rest rest)
          (list foo opt1 opt2
                rest)))
@@ -798,6 +807,18 @@ thenret x
 
 ;;; Test: indent-74
 ;;
+;; sly-lisp-lambda-list-keyword-parameter-alignment: t
+;; sly-lisp-lambda-list-keyword-alignment: nil
+
+(flet ((foo (foo &optional opt1
+                           opt2
+             &rest rest)
+         (list foo opt1 opt2
+               rest)))
+  ...)
+
+;;; Test: indent-75
+;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: nil
 ;; sly-lisp-lambda-list-keyword-alignment: t
 
@@ -808,7 +829,7 @@ thenret x
                rest)))
   ...)
 
-;;; Test: indent-75
+;;; Test: indent-76
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -820,7 +841,7 @@ thenret x
                rest)))
   ...)
 
-;;; Test: indent-76
+;;; Test: indent-77
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -836,7 +857,7 @@ thenret x
                    rest)))
   ...)
 
-;;; Test: indent-77
+;;; Test: indent-78
 ;;
 ;; sly-lisp-align-keywords-in-calls: t
 
@@ -846,7 +867,7 @@ thenret x
            #-quux nil
      :zot t)
 
-;;; Test: indent-78
+;;; Test: indent-79
 ;;
 ;; sly-lisp-align-keywords-in-calls: t
 
@@ -856,12 +877,12 @@ thenret x
                  #+zot nil
            :zot t)
 
-;;; Test: indent-79
+;;; Test: indent-80
 
 (foo #+quux :quux #+quux t
      #-quux :zoo #-quux t)
 
-;;; Test: indent-80
+;;; Test: indent-81
 ;;
 ;; sly-lisp-align-keywords-in-calls: t
 
@@ -870,7 +891,7 @@ thenret x
            #+quux :quux #+quux t
            :zot t)
 
-;;; Test: indent-81
+;;; Test: indent-82
 ;;
 ;; sly-lisp-align-keywords-in-calls: t
 
@@ -879,7 +900,7 @@ thenret x
            #+quux #+quux :quux t
            :zot t)
 
-;;; Test: indent-82
+;;; Test: indent-83
 ;;
 ;; sly-lisp-align-keywords-in-calls: t
 
@@ -889,7 +910,7 @@ thenret x
            :quux #+quux t
            :zot t)
 
-;;; Test: indent-83
+;;; Test: indent-84
 ;;
 ;; sly-lisp-align-keywords-in-calls: t
 
@@ -899,27 +920,27 @@ thenret x
            :quux t
            :zot t)
 
-;;; Test: indent-84
+;;; Test: indent-85
 
 (and ;; Foo
      (something)
      ;; Quux
      (more))
 
-;;; Test: indent-85
+;;; Test: indent-86
 
 (and      ;; Foo
      (something)
      ;; Quux
      (more))
 
-;;; Test: indent-86
+;;; Test: indent-87
 
 (foo (
       bar quux
       zor))
 
-;;; Test: indent-87
+;;; Test: indent-88
 ;;
 ;; sly-lisp-lambda-list-keyword-parameter-alignment: t
 ;; sly-lisp-lambda-list-keyword-alignment: t
@@ -935,7 +956,7 @@ thenret x
   (list foo opt1 opt2
         rest))
 
-;;; Test: indent-88
+;;; Test: indent-89
 
 (defstruct (foo
             (:constructor make-foo
@@ -944,19 +965,19 @@ thenret x
   bar
   quux)
 
-;;; Test: indent-89
+;;; Test: indent-90
 
 (define-tentative-thing foo
     (bar)
   quux)
 
-;;; Test: indent-90
+;;; Test: indent-91
 
 (define-tentative-thing foo
   bar
   quux)
 
-;;; Test: indent-91
+;;; Test: indent-92
 ;;
 ;; sly-lisp-loop-indent-body-forms-relative-to-loop-start: t
 
@@ -966,7 +987,7 @@ thenret x
           bar
           baz))
 
-;;; Test: indent-92
+;;; Test: indent-93
 ;;
 ;; sly-lisp-loop-indent-body-forms-relative-to-loop-start: t
 ;; sly-lisp-loop-clauses-indentation: 4
@@ -978,7 +999,7 @@ thenret x
           bar
           baz))
 
-;;; Test: indent-93
+;;; Test: indent-94
 ;;
 ;; sly-lisp-loop-clauses-indentation: 4
 
@@ -989,7 +1010,7 @@ thenret x
               bar
               baz))
 
-;;; Test: indent-94
+;;; Test: indent-95
 ;;
 ;; sly-lisp-loop-clauses-indentation: 4
 ;; sly-lisp-loop-body-forms-indentation: 1
@@ -1001,7 +1022,7 @@ thenret x
            bar
            baz))
 
-;;; Test: indent-95
+;;; Test: indent-96
 ;;
 ;; sly-lisp-loop-body-forms-indentation: 1
 ;; sly-lisp-loop-indent-body-forms-relative-to-loop-start: t

--- a/test/sly-cl-indent-test.txt
+++ b/test/sly-cl-indent-test.txt
@@ -125,10 +125,10 @@
               ;; the body is ...
               (indented to the above comment)
               (ZMACS gets this wrong)
-           and do this
-           and do that
+           and do (this)
+           and do (that)
            and when foo
-                 do the-other
+                 do (the-other)
                  and cry
       when this-is-a-short-condition do
         (body code of the when)


### PR DESCRIPTION
The goal of this PR is to indent `CL:LOOP` forms by parsing the body instead of using regexps on the surrounding context.

This is done in two steps:
1. The new function `sly--lisp-indent-loop-macro-partial-parse` takes the current `LOOP` body and parses it, collecting each form in it as a cons cell `(POS . OBJ)` where `POS` is where the object starts and `OBJ` is the object's string representation as it is written in the buffer if it is an atom and nil if it is a compound form.
2. The function `sly--lisp-indent-loop-macro-1` was completely rewritten such that it uses a `consume-forms` sub-function in a `cl-labels` which recursively moves along this `((POS . OBJ)...)` that we obtained before.  It does this according to the spec given to it, the documentation of which is provided in the new variable `sly--lisp-indent-loop-macro-allowed-bodies-alist`, which also contains the specs of all clauses in a `LOOP` body.  The goal was to make it be as one-to-one with the spec as it could be.

Some explanation of how `consume-forms` works: It receives four things: the current `((POS . OBJ)...)` list (anything that came before we "moved across"), the spec that it is expecting, the column the current body begins at, and the offset relative to it.  If it manages to parse until we reach the end of the forms, we return the current body plus the offset relative to it.  If it parses it, finishes, and we still have left over forms, then it instead returns those forms.  The sequence specs are such that the next subspec will be matched against these leftover forms instead.  The entry point, the first `consume-forms` that is called is one that will match against clauses indefinitely.  `consume-forms` may also return `nil` if it fails to match.  (This is because the list `((POS . OBJ)...)` is actually made to be terminated by a `t` and not `nil`.)  All of these *should* guarantee that we indent the target line appropriately.

Now, a couple (or more) problems with the current state of this code:
- It is slow.  While this is not noticable with all calls, some calls are very obviously delayed.  A simple paredit-reindent-defun is a great showcase of this problem.  I suspect pulling out `consume-forms` into its own function will help with that, however some optimizations may need to be done even then.
- `sly--lisp-indent-loop-macro-allowed-bodies-alist` is... fine, actually.  It is by no means perfect, and I had to make some compromises in order to avoid having to bookkeep a bunch of stuff, but it is for the most part understandable.  Some work on it may be done, if better ways to shape it are found, but it is decent.
- `sly--lisp-indent-loop-macro-partial-parse` uses naive-ish code to determine what is and isn't a compound form, taking into account the standard reader macros.  Some tests should be done to ensure that these work.  Some of the more exotic cases, in case too difficult to handle, I think may be ignored, but as long as this code works then so should `sly--lisp-indent-loop-macro-1`, as far as I can tell.

TODOs:
- `sly-lisp-loop-body-forms-indentation` should be made to be recognized in the spec, likely by changing the existing 2-indents by `&body`-indents.  This brings up the issue of what the current 4-indents should be indented as, however.  Possibly as a `&special` indent which defaults to double the `&body`-indent.  There are also 0-indents, and while these can stay as hard-coded to 0, maybe a `&join`-indent could be introduced which would default to 0 instead.  I don't know at this point if this is good or not, but some sort of a decision needs to be made.
- `sly-lisp-loop-indent-body-forms-relative-to-loop-start` should... not exist.  I have no idea why it even exists, and I have no appreciation whatsoever for it.  I vote for simply removing it altogether.  The implementation, if I have to allow for its existance, and in fact, the whole conceptual basis for the code is made void by this variable.  I have no intentions to add support for it.
- The terminating closing parenthesis is not indented appropriately when it is on its own line.  I do not yet know why, it's something that I need to look into.
- You will notice that I have changed some of the tests so that `do`s bodies are compound forms.  This makes implementation possible and establishes consistency with the spec.  The test `indent-11` is also invalid, due to the `when here's something I used to botch` line.  If some other invalid examples exist, they should either be fixed or explicitly be made examples of invalid loops.  I can go through them, but then we move on to the next point:
- Currently `sly--lisp-indent-loop-macro-partial-parse` only parses up to the form to be indented.  This has two benefits:
  1. It is in theory safe; we cannot have any incomplete sexps until the form we are trying to indent, otherwise we would not be indenting `LOOP` but a different sexp instead.  This seems to work so far but a more rigorous check is needed at some point.
  2. It allows for a very simple way to determine whether we are done with the recursive `consume-forms` or not: If we are at the end of the list of forms then we have figured out the indentation.
  This has a single problem however: The form
  ```
    when foo do
      (bar)
  ```
  should be indented as above if this concludes the clause but if it is followed by more `and`-chained clauses it should be
  ```
    when foo do
               (bar)
             and do
               (baz)
  ```
  instead.  This is not possible without looking ahead, and I am not yet sure how to do this, aside from changing the way the function works to finding the indentation of every form (it only does for forms before and discards it immediately) and only returning the one we want.  This is a challenge that I am not yet willing to take on.
- The way the tests are laid out currently, the "correct" indentation for
  ```
    and if foo
          do (the-other)
  ```
  appears to be to take `if` as the starting point of the body - an inline body - however this is not consistent if we say that `else if` indents relative to `else` which would imply that `if` actually starts a not-inline body.  This could possibly be reserved if we were to say that `and`s subclauses must start inline bodies but currently only the body itself can signal whether it is inline or not, not the thing starting it, so if this is indeed considered the "correct" indentation then this would take additional work to fix, though it would not be impossible.  However, I suggest that we simply say `and <clause>` is indented relative to `and`.
- In tests `indent-69`, `indent-70`, and `indent-71`, body comments are aligned against each other.  I cannot see a reason why this would be the case; the only comments that align against each other are supposed to be single comments.  The correct indentation should instead have the second body comment align against where the body would go. \
  There is however a problem, in that a comment is currently treated the same as a compound form and moves along the spec, which is something that I need to fix at some point.  It should not be too difficult hopefully.

These are all the things I can immediately think of, there may be and likely are many more issues and things that need to be ironed out.  I did not want to end up going too out of scope in #471 so I have this as a PR, but it is actually a draft.