### PR TITLE
Fix read-symbol-name after recent completion changes

### DIFF
--- a/lib/sly-completion.el
+++ b/lib/sly-completion.el
@@ -752,7 +752,7 @@ The user is prompted if a prefix argument is in effect, if there is no
 symbol at point, or if QUERY is non-nil."
   (let* ((sym-at-point (sly-symbol-at-point))
          (completion-category-overrides
-          (cons '(sly-completion (styles . (backend)))
+          (cons '(sly-completion (styles . (sly--external-completion)))
                 completion-category-overrides))
          (wrapper (sly--completion-function-wrapper sly-complete-symbol-function))
          (do-it (lambda () (completing-read prompt wrapper nil nil sym-at-point))))


### PR DESCRIPTION
Completion when jumping to source of a symbol was referencing an old completion style that no longer exists.