### PR TITLE
Improve the clasp slynk backend and fix a non-standard loop macro

### DIFF
--- a/contrib/slynk-stickers.lisp
+++ b/contrib/slynk-stickers.lisp
@@ -242,7 +242,7 @@ after.")
                                       increment)
   "Return two values: a RECORDING and its position in *RECORDINGS*.
 Start searching from position FROM, an index in *RECORDINGS* which is
-successfuly increased by INCREMENT before using that to index
+successively increased by INCREMENT before using that to index
 *RECORDINGS*."
   (loop for starting-position in `(,from ,(if (plusp increment)
                                               -1

--- a/contrib/slynk-stickers.lisp
+++ b/contrib/slynk-stickers.lisp
@@ -242,7 +242,7 @@ after.")
                                       increment)
   "Return two values: a RECORDING and its position in *RECORDINGS*.
 Start searching from position FROM, an index in *RECORDINGS* which is
-successibely increased by INCREMENT before using that to index
+successfuly increased by INCREMENT before using that to index
 *RECORDINGS*."
   (loop for starting-position in `(,from ,(if (plusp increment)
                                               -1
@@ -250,14 +250,16 @@ successibely increased by INCREMENT before using that to index
         ;; this funky scheme has something to do with rollover
         ;; semantics probably
         ;;
-        for inc in `(,increment ,(if (plusp increment) 1 -1))
+        for inc in `(,increment ,(if (plusp from) 1 -1))
         for (rec idx) = (loop for cand-idx = (incf starting-position
                                                    inc)
-                              while (< -1 cand-idx (length *recordings*))
-                              for recording = (aref *recordings* cand-idx)
-                              for sid = (id-of (sticker-of recording))
-                              unless (funcall ignore-p sid)
-                                return (list recording cand-idx))
+                              if (< -1 cand-idx (length *recordings*))
+                                do (let* ((recording (aref *recordings* cand-idx))
+                                          (sid (id-of (sticker-of recording))))
+                                     (unless (funcall ignore-p sid)
+                                       (return (list recording cand-idx))))
+                              else
+                                do (return (list nil cand-idx)))
         when rec
           return (values rec idx)))
 

--- a/slynk/backend/clasp.lisp
+++ b/slynk/backend/clasp.lisp
@@ -313,6 +313,7 @@
             (fasl-file)
             (warnings-p)
             (failure-p))
+        (declare (ignorable warnings-p))
         (unwind-protect
             (progn
                (with-open-file (tmp-stream tmp-file :direction :output
@@ -349,29 +350,6 @@
 (defimplementation macroexpand-all (form &optional env)
   (declare (ignore env))
   (macroexpand form))
-
-;;; modified from sbcl.lisp
-(defimplementation collect-macro-forms (form &optional environment)
-  (let ((macro-forms '())
-        (compiler-macro-forms '())
-        (function-quoted-forms '()))
-    (cmp:code-walk
-     (lambda (form environment)
-       (when (and (consp form)
-                  (symbolp (car form)))
-         (cond ((eq (car form) 'function)
-                (push (cadr form) function-quoted-forms))
-               ((member form function-quoted-forms)
-                nil)
-               ((macro-function (car form) environment)
-                (push form macro-forms))
-               ((not (eq form (sys:compiler-macroexpand-1 form environment)))
-                (push form compiler-macro-forms))))
-       form)
-     form environment)
-    (values macro-forms compiler-macro-forms)))
-
-
 
 
 
@@ -527,19 +505,6 @@
 (defimplementation activate-stepping (frame)
   (declare (ignore frame))
   (core:set-breakstep))
-
-(defimplementation sldb-stepper-condition-p (condition)
-  (typep condition 'clasp-debug:step-form))
-
-(defimplementation sldb-step-into ()
-  (invoke-restart 'clasp-debug:step-into))
-
-(defimplementation sldb-step-next ()
-  (invoke-restart 'clasp-debug:step-over))
-
-(defimplementation sldb-step-out ()
-  ;; FIXME: This stops stepping entirely. Clasp does not have step out yet.
-  (invoke-restart 'continue))
 
 #+clasp-working
 (defimplementation gdb-initial-commands ()

--- a/slynk/slynk-backend.lisp
+++ b/slynk/slynk-backend.lisp
@@ -196,7 +196,7 @@ Backends implement these functions using DEFIMPLEMENTATION."
        (if (member ',sym *interface-functions*)
            (setq *unimplemented-interfaces*
                  (remove ',sym *unimplemented-interfaces*))
-           (warn "DEFIMPLEMENTATION of undefined interface (~S)" ',sym))
+           (warn "DEFIMPLEMENTATION of undefined interface (~S)" ',name))
        ',sym)))
 
 (defun warn-unimplemented-interfaces ()

--- a/slynk/slynk-loader.lisp
+++ b/slynk/slynk-loader.lisp
@@ -103,7 +103,9 @@
   #+clisp     (let ((s (lisp-implementation-version)))
                 (subseq s 0 (position #\space s)))
   #+armedbear (lisp-implementation-version)
-  #+ecl (ecl-version-string) )
+  #+ecl (ecl-version-string)
+  #+clasp (clasp-version-string)
+  )
 
 (defun unique-dir-name ()
   "Return a name that can be used as a directory name that is

--- a/slynk/slynk-loader.lisp
+++ b/slynk/slynk-loader.lisp
@@ -136,7 +136,7 @@ operating system, and hardware architecture."
 (defun sly-version-string ()
   "Return a string identifying the SLY version.
 Return nil if nothing appropriate is available."
-  (let ((this-file #.(or *compile-file-truename* *load-truename*)))
+  (let ((this-file #.(or #-clasp *compile-file-truename* *load-truename*)))
     (with-open-file (s (make-pathname :name "sly" :type "el"
                                       :directory (butlast
                                                   (pathname-directory this-file)


### PR DESCRIPTION
I've upgraded the clasp slynk backend so that clasp can make full use of sly's enhancements.
I also found a loop macro in search-for-recording-1 that put a while clause before some for clauses and that gives our symbolics loop macro some trouble.