### PR TITLE
sly-sexp-at-point: error only with both `interactive` and `errorp`

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -7392,7 +7392,7 @@ as nil.  With non-nil STRINGP, only look for strings"
                    (not (eq (syntax-class (syntax-after (car bounds)))
                             (char-syntax ?\"))))
           (if (and interactive
-                   interactive)
+                   errorp)
               (user-error "No string at point")
             (throw 'return nil)))
         (when interactive


### PR DESCRIPTION
Seems like that was what was intended, but it ended up only testing for `interactive` twice instead.