### PR TITLE
Fix style warning about unknown :FORCE keyword arg to close-channel

### DIFF
--- a/slynk/slynk.lisp
+++ b/slynk/slynk.lisp
@@ -521,7 +521,8 @@ corresponding values in the CDR of VALUE."
 (defun channel-thread-id (channel)
   (slynk-backend:thread-id (channel-thread channel)))
 
-(defmethod close-channel (channel &key)
+(defmethod close-channel (channel &key force)
+  (declare (ignore force))
   (let ((probe (find-channel (channel-id channel))))
     (cond (probe (setf (channels) (delete probe (channels))))
           (t (error "Can't close invalid channel: ~a" channel)))))


### PR DESCRIPTION
Hi!

Just now, loading Slynk, I got this warning:

``` lisp
; in: DEFUN SLYNK::CLOSE-CONNECTION%
;     (SLYNK::CLOSE-CHANNEL SLYNK::C :FORCE T)
; 
; caught STYLE-WARNING:
;   :FORCE is not a known argument keyword.
```

The problem was with the initial `slynk::close-channel` definition (a `defmethod` in slynk/slynk.lisp) not allowing additional keyword arguments, with `slynk::close-connection` providing a previously unknown argument. So I went ahead and fixed arglists with an `&allow-other-keys`