### PR TITLE
Add xref.el integration for cross-reference navigation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ check-unit: compile
 		--eval "(require 'sly-messages-unit-tests \"test/sly-messages-unit-tests\")" \
 		--eval "(require 'sly-hyperspec-unit-tests \"test/sly-hyperspec-unit-tests\")" \
 		--eval "(require 'sly-common-unit-tests \"test/sly-common-unit-tests\")" \
+		--eval "(require 'sly-xref-unit-tests \"test/sly-xref-unit-tests\")" \
 		--eval "(ert-run-tests-batch-and-exit \"^sly-.*-unit--\")"
 
 # Unit tests with coverage (requires undercover.el)
@@ -72,6 +73,7 @@ check-unit-coverage: compile
 		--eval "(require 'sly-messages-unit-tests \"test/sly-messages-unit-tests\")" \
 		--eval "(require 'sly-hyperspec-unit-tests \"test/sly-hyperspec-unit-tests\")" \
 		--eval "(require 'sly-common-unit-tests \"test/sly-common-unit-tests\")" \
+		--eval "(require 'sly-xref-unit-tests \"test/sly-xref-unit-tests\")" \
 		--eval "(ert-run-tests-batch-and-exit \"^sly-.*-unit--\")"
 	@echo "Coverage report generated in coverage/"
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,57 @@ compile-test: $(TEST_ELCFILES)
 
 # Automated tests
 #
+# Unit tests (no Lisp required)
+UNIT_TEST_FILES := test/sly-parse-unit-tests.el \
+		   test/sly-completion-unit-tests.el \
+		   test/sly-buttons-unit-tests.el \
+		   test/sly-messages-unit-tests.el \
+		   test/sly-hyperspec-unit-tests.el \
+		   test/sly-common-unit-tests.el
+
+check-unit: compile
+	$(EMACS) -Q --batch $(LOAD_PATH) -L test			\
+		--eval "(require 'ert)"					\
+		--eval "(require 'sly)"					\
+		--eval "(require 'sly-unit-tests \"lib/sly-unit-tests\")" \
+		--eval "(require 'sly-test-mocks \"test/sly-test-mocks\")" \
+		--eval "(require 'sly-parse-unit-tests \"test/sly-parse-unit-tests\")" \
+		--eval "(require 'sly-completion-unit-tests \"test/sly-completion-unit-tests\")" \
+		--eval "(require 'sly-buttons-unit-tests \"test/sly-buttons-unit-tests\")" \
+		--eval "(require 'sly-messages-unit-tests \"test/sly-messages-unit-tests\")" \
+		--eval "(require 'sly-hyperspec-unit-tests \"test/sly-hyperspec-unit-tests\")" \
+		--eval "(require 'sly-common-unit-tests \"test/sly-common-unit-tests\")" \
+		--eval "(ert-run-tests-batch-and-exit \"^sly-.*-unit--\")"
+
+# Unit tests with coverage (requires undercover.el)
+check-unit-coverage: compile
+	@mkdir -p coverage
+	$(EMACS) -Q --batch $(LOAD_PATH) -L test			\
+		--eval "(require 'ert)"					\
+		--eval "(require 'sly-test-coverage \"test/sly-test-coverage\")" \
+		--eval "(require 'sly)"					\
+		--eval "(require 'sly-unit-tests \"lib/sly-unit-tests\")" \
+		--eval "(require 'sly-test-mocks \"test/sly-test-mocks\")" \
+		--eval "(require 'sly-parse-unit-tests \"test/sly-parse-unit-tests\")" \
+		--eval "(require 'sly-completion-unit-tests \"test/sly-completion-unit-tests\")" \
+		--eval "(require 'sly-buttons-unit-tests \"test/sly-buttons-unit-tests\")" \
+		--eval "(require 'sly-messages-unit-tests \"test/sly-messages-unit-tests\")" \
+		--eval "(require 'sly-hyperspec-unit-tests \"test/sly-hyperspec-unit-tests\")" \
+		--eval "(require 'sly-common-unit-tests \"test/sly-common-unit-tests\")" \
+		--eval "(ert-run-tests-batch-and-exit \"^sly-.*-unit--\")"
+	@echo "Coverage report generated in coverage/"
+
+# All tests with coverage
+check-coverage: compile compile-contrib
+	@mkdir -p coverage
+	$(EMACS) -Q --batch $(LOAD_PATH) -L test			\
+		--eval "(require 'sly-test-coverage \"test/sly-test-coverage\")" \
+		--eval "(require 'sly-tests \"lib/sly-tests\")"	\
+		--eval "(setq inferior-lisp-program \"$(LISP)\")"	\
+		--eval '(sly-batch-test t)'
+	@echo "Coverage report generated in coverage/"
+
+# Integration tests (require Lisp)
 check: check-core check-fancy
 
 check-core: SELECTOR=t
@@ -97,7 +148,8 @@ Main targets\n\
 all             -- compile all .el files\n\
 compile         -- compile just core SLY\n\
 compile-contrib -- compile just contribs\n\
-check           -- run tests in batch mode\n\
+check           -- run integration tests in batch mode\n\
+check-unit      -- run unit tests (no Lisp required)\n\
 clean           -- delete generated files\n\
 doc-help        -- print help about doc targets\n\
 help-vars       -- print info about variables\n\
@@ -111,4 +163,4 @@ LISP      -- program to start Lisp ($(LISP))\n\
 SELECTOR  -- selector for ERT tests ($(SELECTOR))\n"
 
 .PHONY: all clean compile compile-contrib check check-core \
-	check-fancy dochelp help-vars
+	check-fancy check-unit dochelp help-vars

--- a/doc/CONTRIB-ARCHITECTURE.md
+++ b/doc/CONTRIB-ARCHITECTURE.md
@@ -1,0 +1,810 @@
+# SLY Contrib System Architecture
+
+This document provides a comprehensive guide to SLY's contrib (contribution) system, including how to understand existing contribs and how to create new ones.
+
+## Overview
+
+The contrib system allows SLY to be extended with optional features that can be loaded on demand. Each contrib can provide functionality on both the Emacs side (Elisp) and the SLYNK server side (Common Lisp).
+
+**Key characteristics:**
+- Contribs are optional - core SLY works without them
+- Dependencies are automatically resolved
+- Both sides (Emacs + Lisp) can be extended
+- Hot loading/unloading is supported
+
+---
+
+## 1. Contrib Structure
+
+### 1.1 File Organization
+
+A typical contrib consists of:
+
+```
+contrib/
+├── sly-<name>.el        # Emacs side (user-facing)
+├── slynk-<name>.lisp    # SLYNK side (server, optional)
+└── sly-<name>-tests.el  # Tests (in test/ directory)
+```
+
+**Naming conventions:**
+- Emacs files: `sly-<name>.el`
+- SLYNK files: `slynk-<name>.lisp`
+- The `<name>` must match between paired files
+
+### 1.2 Core Components
+
+Each Emacs-side contrib defines itself using `define-sly-contrib`:
+
+```elisp
+(define-sly-contrib sly-example
+  "One-line description of what this contrib does."
+  (:authors "Author Name <email@example.com>")
+  (:license "GPL")
+  (:sly-dependencies sly-other-contrib)      ; Other Elisp contribs
+  (:slynk-dependencies slynk/example)        ; SLYNK modules to load
+  (:on-load (example-initialize))            ; Run when enabled
+  (:on-unload (example-cleanup)))            ; Run when disabled
+```
+
+---
+
+## 2. The Contrib Macro
+
+### 2.1 `define-sly-contrib` Syntax
+
+```elisp
+(define-sly-contrib NAME DOCSTRING &rest OPTIONS)
+```
+
+**OPTIONS keywords:**
+
+| Keyword | Value | Purpose |
+|---------|-------|---------|
+| `:authors` | string or list | Author information |
+| `:license` | string | License identifier |
+| `:sly-dependencies` | symbol or list | Required Elisp contribs |
+| `:slynk-dependencies` | symbol or list | Required SLYNK modules |
+| `:on-load` | form(s) | Code to run when enabling |
+| `:on-unload` | form(s) | Code to run when disabling |
+
+### 2.2 Generated Functions
+
+The macro generates these functions:
+
+```elisp
+;; For a contrib named 'sly-example':
+(defun sly-example-init ()
+  "Enable sly-example contrib."
+  ...)
+
+(defun sly-example-unload ()
+  "Disable sly-example contrib."
+  ...)
+```
+
+### 2.3 Internal Data Structure
+
+```elisp
+;; sly.el:6911-6920
+(cl-defstruct (sly-contrib (:conc-name sly-contrib.))
+  enabled-p           ; Is this contrib currently enabled?
+  name                ; Symbol naming the contrib
+  sly-dependencies    ; List of required Elisp contribs
+  slynk-dependencies  ; List of required SLYNK modules
+  enable              ; Enable function
+  disable             ; Disable function
+  authors             ; Author string or list
+  license)            ; License string
+```
+
+---
+
+## 3. Lifecycle Management
+
+### 3.1 Loading Sequence
+
+When `sly-setup` is called (typically in user's init file):
+
+```elisp
+(sly-setup '(sly-fancy sly-mrepl))
+```
+
+The following happens:
+
+```
+1. Add contrib/ to load-path
+       │
+       ▼
+2. For each contrib in list:
+   ├── (require 'sly-<name>)
+   └── Contrib struct registered
+       │
+       ▼
+3. Calculate all dependencies (recursive)
+       │
+       ▼
+4. Disable "forgotten" contribs
+   (previously enabled, not in new list)
+       │
+       ▼
+5. Enable new contribs (in dependency order)
+   ├── Enable sly-dependencies first
+   ├── Register slynk-dependencies
+   ├── If connected: load SLYNK modules
+   └── Run :on-load code
+```
+
+### 3.2 Enable Sequence (Detailed)
+
+```elisp
+;; sly.el:6948-6978 (simplified)
+(defun sly-contrib--enable (contrib)
+  ;; 1. Enable SLY dependencies first
+  (dolist (dep (sly-contrib.sly-dependencies contrib))
+    (sly-enable-contrib dep))
+
+  ;; 2. Register SLYNK dependencies
+  (dolist (dep (sly-contrib.slynk-dependencies contrib))
+    (push dep sly-contrib--required-slynk-modules))
+
+  ;; 3. Load SLYNK modules if connected
+  (when (sly-connected-p)
+    (sly-contrib--load-slynk-dependencies))
+
+  ;; 4. Run :on-load code
+  (funcall (sly-contrib.enable contrib))
+
+  ;; 5. Mark as enabled
+  (setf (sly-contrib.enabled-p contrib) t))
+```
+
+### 3.3 SLYNK Module Loading
+
+```elisp
+;; sly.el:6993-7010 (simplified)
+(defun sly-contrib--load-slynk-dependencies ()
+  "Load required SLYNK modules on current connection."
+  (let ((modules-to-load sly-contrib--required-slynk-modules))
+    (when modules-to-load
+      (sly-eval-async
+       `(slynk:slynk-require ',modules-to-load)
+       (lambda (result)
+         (message "Loaded SLYNK modules: %s" result))))))
+```
+
+On the SLYNK side, `slynk-require` handles loading:
+
+```lisp
+;; slynk.lisp:2991-3008
+(defslyfun slynk-require (modules)
+  "Load MODULES into the running Lisp."
+  (dolist (module (ensure-list modules))
+    (require-module module))
+  *modules*)  ; Return list of loaded modules
+```
+
+### 3.4 Disable Sequence
+
+```elisp
+(defun sly-contrib--disable (contrib)
+  ;; 1. Disable dependents first (reverse order)
+  (dolist (dep (sly-contrib--dependents contrib))
+    (sly-disable-contrib dep))
+
+  ;; 2. Run :on-unload code
+  (funcall (sly-contrib.disable contrib))
+
+  ;; 3. Unregister SLYNK dependencies
+  (dolist (dep (sly-contrib.slynk-dependencies contrib))
+    (setq sly-contrib--required-slynk-modules
+          (remove dep sly-contrib--required-slynk-modules)))
+
+  ;; 4. Mark as disabled
+  (setf (sly-contrib.enabled-p contrib) nil))
+```
+
+---
+
+## 4. Existing Contribs
+
+### 4.1 Meta-Contrib: sly-fancy
+
+```elisp
+;; contrib/sly-fancy.el
+(define-sly-contrib sly-fancy
+  "Load commonly used SLY contribs in one bundle."
+  (:sly-dependencies sly-mrepl
+                     sly-autodoc
+                     sly-fancy-inspector
+                     sly-fancy-trace
+                     sly-scratch
+                     sly-package-fu
+                     sly-fontifying-fu
+                     sly-trace-dialog
+                     sly-stickers
+                     sly-indentation
+                     sly-tramp))
+```
+
+This is the default contrib loaded when SLY starts. It bundles the "nice-to-have" features.
+
+### 4.2 sly-mrepl (Multiple REPLs)
+
+**Purpose:** Provides multiple independent REPL buffers over a single connection.
+
+**Files:**
+- `contrib/sly-mrepl.el` (1,568 lines)
+- `contrib/slynk-mrepl.lisp` (~500 lines)
+
+**Key features:**
+- Multiple REPL instances per connection
+- Independent evaluation contexts
+- comint.el-based UI with history
+- Proper output routing
+
+**Elisp highlights:**
+```elisp
+(define-sly-contrib sly-mrepl
+  "Multiple REPLs over single connection."
+  (:slynk-dependencies slynk/mrepl)
+  (:on-load
+   (add-hook 'sly-connected-hook 'sly-mrepl-on-connection))
+  (:on-unload
+   (remove-hook 'sly-connected-hook 'sly-mrepl-on-connection)))
+
+(define-derived-mode sly-mrepl-mode comint-mode "mrepl"
+  "Mode for SLY MREPL buffers."
+  ...)
+```
+
+**SLYNK side:**
+```lisp
+;; Creates channel for REPL I/O
+(defclass mrepl (channel)
+  ((read-mode :initform :eval)
+   (pending-errors :initform nil)))
+
+(defmethod channel-send ((r mrepl) (selector (eql :eval)) args)
+  ;; Evaluate form and send result back
+  ...)
+```
+
+### 4.3 sly-stickers (Live Annotations)
+
+**Purpose:** Mark expressions and see their values recorded as code executes.
+
+**Files:**
+- `contrib/sly-stickers.el` (1,358 lines)
+- `contrib/slynk-stickers.lisp` (~600 lines)
+
+**Key features:**
+- Non-invasive code instrumentation
+- Value recording with timestamps
+- Zombie sticker detection
+- Interactive sticker management
+
+**How it works:**
+1. User places sticker on expression
+2. Code is macro-expanded to record values
+3. Values streamed to Emacs
+4. Displayed inline or in separate buffer
+
+**Elisp highlights:**
+```elisp
+(define-sly-contrib sly-stickers
+  "Live code annotations for debugging."
+  (:slynk-dependencies slynk/stickers)
+  (:on-load
+   (add-hook 'sly-compilation-finished-hook 'sly-stickers--compile-region-aware))
+  (:on-unload
+   (remove-hook 'sly-compilation-finished-hook 'sly-stickers--compile-region-aware)))
+
+;; Sticker overlay management
+(defun sly-stickers--stickers-in (beg end)
+  "Return stickers overlapping BEG to END."
+  ...)
+```
+
+### 4.4 sly-trace-dialog (Interactive Tracing)
+
+**Purpose:** Interactive trace browser with hierarchical display.
+
+**Files:**
+- `contrib/sly-trace-dialog.el` (743 lines)
+- `contrib/slynk-trace-dialog.lisp` (~300 lines)
+
+**Key features:**
+- Tree-structured trace display
+- Entry/exit value inspection
+- Interactive navigation
+- Trace recording/playback
+
+### 4.5 sly-autodoc (Automatic Documentation)
+
+**Purpose:** Display function signatures in echo area.
+
+**Files:**
+- `contrib/sly-autodoc.el` (188 lines)
+- Uses `slynk/arglists` module
+
+**How it works:**
+```elisp
+(define-sly-contrib sly-autodoc
+  "Display argument lists in echo area."
+  (:slynk-dependencies slynk/arglists)
+  (:on-load
+   (add-hook 'sly-editing-mode-hook 'sly-autodoc-mode))
+  (:on-unload
+   (remove-hook 'sly-editing-mode-hook 'sly-autodoc-mode)))
+
+;; Uses eldoc for display
+(defun sly-autodoc--eldoc-function ()
+  "Query SLYNK for arglist at point."
+  (sly-eval-async `(slynk:autodoc ',(sly-parse-context))
+    #'sly-autodoc--display))
+```
+
+### 4.6 sly-fancy-inspector (Enhanced Inspector)
+
+**Purpose:** Rich object inspection with CLOS awareness.
+
+**Files:**
+- `contrib/sly-fancy-inspector.el` (22 lines - just loads SLYNK)
+- `contrib/slynk-fancy-inspector.lisp` (1,300+ lines)
+
+### 4.7 sly-package-fu (Package Utilities)
+
+**Purpose:** Package manipulation commands.
+
+**Files:**
+- `contrib/sly-package-fu.el` (448 lines)
+- `contrib/slynk-package-fu.lisp` (~100 lines)
+
+**Features:**
+- Export symbol at point
+- Unexport symbol
+- Import symbol
+- Add to defpackage
+
+### 4.8 sly-fontifying-fu (Enhanced Highlighting)
+
+**Purpose:** Additional syntax highlighting.
+
+**File:** `contrib/sly-fontifying-fu.el` (206 lines)
+
+**Features:**
+- Highlight `with-*`, `define-*` forms
+- Dim reader-conditionals for other implementations
+- Enhanced keyword highlighting
+
+### 4.9 sly-profiler (Profiling UI)
+
+**Purpose:** Function timing/profiling interface.
+
+**Files:**
+- `contrib/sly-profiler.el` (155 lines)
+- `contrib/slynk-profiler.lisp` (~200 lines)
+
+### 4.10 sly-tramp (Remote Lisp)
+
+**Purpose:** Support for remote Lisp via TRAMP.
+
+**File:** `contrib/sly-tramp.el` (123 lines)
+
+**Features:**
+- Path translation between local and remote
+- Per-host configuration
+- SSH tunnel integration
+
+### 4.11 sly-retro (SLIME Compatibility)
+
+**Purpose:** Allow SLIME clients to connect to SLYNK.
+
+**Files:**
+- `contrib/sly-retro.el` (22 lines)
+- `contrib/slynk-retro.lisp` (45 lines)
+
+Translates SWANK protocol to SLYNK protocol.
+
+### 4.12 sly-scratch (Scratch Buffer)
+
+**Purpose:** Lisp-mode scratch buffer.
+
+**File:** `contrib/sly-scratch.el` (45 lines)
+
+### 4.13 sly-indentation (Dynamic Indentation)
+
+**Purpose:** Load indentation rules from Lisp.
+
+**Files:**
+- `contrib/sly-indentation.el` (31 lines)
+- `contrib/slynk-indentation.lisp` (~150 lines)
+
+### 4.14 sly-fancy-trace (Enhanced Tracing)
+
+**Purpose:** Trace local functions and methods.
+
+**File:** `contrib/sly-fancy-trace.el` (68 lines)
+
+---
+
+## 5. Contrib Patterns
+
+### 5.1 Pattern: Simple UI Enhancement
+
+For contribs that only add Emacs-side features:
+
+```elisp
+(define-sly-contrib sly-my-feature
+  "Add MY-FEATURE to SLY."
+  (:on-load
+   (define-key sly-mode-map (kbd "C-c M") 'sly-my-command)
+   (add-hook 'sly-mode-hook 'sly-my-minor-mode))
+  (:on-unload
+   (define-key sly-mode-map (kbd "C-c M") nil)
+   (remove-hook 'sly-mode-hook 'sly-my-minor-mode)))
+
+(define-minor-mode sly-my-minor-mode
+  "Minor mode for MY-FEATURE."
+  :lighter " my"
+  :keymap (make-sparse-keymap)
+  ...)
+
+(defun sly-my-command ()
+  "Do the thing."
+  (interactive)
+  ...)
+```
+
+### 5.2 Pattern: Server Integration
+
+For contribs that need SLYNK-side code:
+
+**Elisp side:**
+```elisp
+(define-sly-contrib sly-server-feature
+  "Feature requiring server-side code."
+  (:slynk-dependencies slynk/server-feature)
+  (:on-load
+   (add-hook 'sly-connected-hook 'sly-server-feature-init))
+  (:on-unload
+   (remove-hook 'sly-connected-hook 'sly-server-feature-init)))
+
+(defun sly-server-feature-init ()
+  "Initialize server-feature on connection."
+  (sly-eval-async '(slynk:server-feature-setup)
+    (lambda (result)
+      (message "Server feature ready: %s" result))))
+
+(defun sly-server-feature-command ()
+  "Call server-side function."
+  (interactive)
+  (sly-eval-async '(slynk:server-feature-do-thing)
+    #'sly-server-feature-handle-result))
+```
+
+**SLYNK side:**
+```lisp
+(defpackage :slynk/server-feature
+  (:use :cl :slynk)
+  (:export #:server-feature-setup
+           #:server-feature-do-thing))
+
+(in-package :slynk/server-feature)
+
+(defslyfun server-feature-setup ()
+  "Initialize server-side feature."
+  (setf *feature-state* (make-feature-state))
+  :ready)
+
+(defslyfun server-feature-do-thing ()
+  "Perform the feature action."
+  (do-the-thing *feature-state*))
+```
+
+**ASDF registration (slynk.asd):**
+```lisp
+(asdf:defsystem :slynk/server-feature
+  :depends-on (:slynk)
+  :components ((:file "contrib/slynk-server-feature")))
+```
+
+### 5.3 Pattern: Channel-Based Communication
+
+For streaming data or stateful interactions:
+
+**Elisp side:**
+```elisp
+(define-sly-contrib sly-streaming
+  "Stream data from Lisp."
+  (:slynk-dependencies slynk/streaming)
+  (:on-load ...))
+
+(defun sly-streaming-start ()
+  "Start streaming data."
+  (interactive)
+  (let ((channel (sly-make-channel #'sly-streaming-handler)))
+    (sly-eval-async `(slynk:streaming-start ,(sly-channel.id channel))
+      #'sly-streaming-started)))
+
+(defun sly-streaming-handler (method &rest args)
+  "Handle messages from streaming channel."
+  (pcase method
+    (:data (apply #'sly-streaming-receive-data args))
+    (:complete (sly-streaming-complete))
+    (_ (message "Unknown method: %s" method))))
+```
+
+**SLYNK side:**
+```lisp
+(defclass streaming-channel (channel)
+  ((data-source :initarg :data-source)))
+
+(defslyfun streaming-start (channel-id)
+  "Start streaming on CHANNEL-ID."
+  (let ((channel (find-channel channel-id)))
+    (spawn (lambda ()
+             (loop for data = (get-next-data)
+                   while data
+                   do (channel-send channel :data data))
+             (channel-send channel :complete)))))
+```
+
+### 5.4 Pattern: Dependency Bundling
+
+For grouping related contribs:
+
+```elisp
+(define-sly-contrib sly-my-bundle
+  "Bundle of related features."
+  (:sly-dependencies sly-feature-a
+                     sly-feature-b
+                     sly-feature-c))
+```
+
+---
+
+## 6. SLYNK Module System
+
+### 6.1 Module Names
+
+SLYNK modules use forward-slash notation:
+- `slynk/mrepl` → loads `slynk-mrepl.lisp`
+- `slynk/stickers` → loads `slynk-stickers.lisp`
+
+### 6.2 ASDF System Definition
+
+All SLYNK modules are defined in `slynk/slynk.asd`:
+
+```lisp
+(asdf:defsystem :slynk/mrepl
+  :depends-on (:slynk)
+  :components ((:file "contrib/slynk-mrepl")))
+
+(asdf:defsystem :slynk/stickers
+  :depends-on (:slynk)
+  :components ((:file "contrib/slynk-stickers")))
+
+;; etc.
+```
+
+### 6.3 Require Hook
+
+Modules can register for load notifications:
+
+```lisp
+;; slynk.lisp:2988
+(defvar *slynk-require-hook* '()
+  "Functions called after modules are loaded.
+Each function receives the list of loaded module names.")
+```
+
+---
+
+## 7. Creating a New Contrib
+
+### 7.1 Step-by-Step Guide
+
+**1. Create Elisp file:**
+
+```elisp
+;; contrib/sly-my-feature.el
+
+;;; Commentary:
+;;
+;; Adds MY-FEATURE to SLY.
+;;
+;;; Code:
+
+(require 'sly)
+
+(define-sly-contrib sly-my-feature
+  "Short description of my feature."
+  (:authors "Your Name <email@example.com>")
+  (:license "GPL")
+  (:slynk-dependencies slynk/my-feature)  ; if needed
+  (:on-load
+   (sly-my-feature-mode 1))
+  (:on-unload
+   (sly-my-feature-mode -1)))
+
+(define-minor-mode sly-my-feature-mode
+  "Minor mode for my feature."
+  :global t
+  :lighter " MyF"
+  (if sly-my-feature-mode
+      (sly-my-feature-enable)
+    (sly-my-feature-disable)))
+
+(defun sly-my-feature-enable ()
+  "Set up my feature."
+  (add-hook 'sly-mode-hook 'sly-my-feature-setup))
+
+(defun sly-my-feature-disable ()
+  "Tear down my feature."
+  (remove-hook 'sly-mode-hook 'sly-my-feature-setup))
+
+(defun sly-my-feature-setup ()
+  "Per-buffer setup."
+  ...)
+
+(provide 'sly-my-feature)
+;;; sly-my-feature.el ends here
+```
+
+**2. Create SLYNK file (if needed):**
+
+```lisp
+;; contrib/slynk-my-feature.lisp
+
+(defpackage :slynk/my-feature
+  (:use :cl :slynk)
+  (:export #:my-feature-info
+           #:my-feature-action))
+
+(in-package :slynk/my-feature)
+
+(defslyfun my-feature-info ()
+  "Return information about my feature."
+  `(:version "1.0"
+    :status :ready))
+
+(defslyfun my-feature-action (arg)
+  "Perform my feature action."
+  (do-something-with arg))
+```
+
+**3. Register ASDF system:**
+
+Add to `slynk/slynk.asd`:
+
+```lisp
+(asdf:defsystem :slynk/my-feature
+  :depends-on (:slynk)
+  :components ((:file "contrib/slynk-my-feature")))
+```
+
+**4. Create tests:**
+
+```elisp
+;; test/sly-my-feature-tests.el
+
+(require 'sly-my-feature)
+(require 'sly-tests)
+
+(def-sly-test my-feature-basic ()
+  "Test basic my-feature functionality."
+  (sly-check ("Feature responds"
+              (sly-eval '(slynk:my-feature-info))))
+  (sly-check ("Action works"
+              (sly-eval '(slynk:my-feature-action 42)))))
+
+(provide 'sly-my-feature-tests)
+```
+
+### 7.2 Best Practices
+
+**DO:**
+- Use `sly-eval-async` for non-blocking operations
+- Clean up hooks/keybindings in `:on-unload`
+- Prefix all functions with `sly-<contrib-name>-`
+- Export SLYNK functions with `defslyfun`
+- Handle connection loss gracefully
+
+**DON'T:**
+- Block with synchronous eval in init code
+- Leave dangling hooks on unload
+- Assume a connection exists
+- Pollute global namespace
+
+---
+
+## 8. Testing Contribs
+
+### 8.1 Test Framework
+
+SLY uses ERT (Emacs Regression Testing) with extensions:
+
+```elisp
+(require 'sly-tests)
+
+(def-sly-test test-name (arg1 arg2)
+  "Docstring for test."
+  '((arg1-val-1 arg2-val-1)    ; Test case 1
+    (arg1-val-2 arg2-val-2))   ; Test case 2
+  (sly-check ("Check description"
+              (some-predicate arg1 arg2))))
+```
+
+### 8.2 Running Tests
+
+```bash
+# Run all tests
+make check
+
+# Run specific contrib tests
+make check-mrepl
+make check-stickers
+```
+
+---
+
+## 9. Contrib Configuration Reference
+
+### 9.1 User Variables
+
+Each contrib may define customizable variables:
+
+```elisp
+(defcustom sly-mrepl-pop-on-connect t
+  "Pop to REPL buffer on connection."
+  :type 'boolean
+  :group 'sly-mrepl)
+
+(defcustom sly-stickers-max-recorded-values 100
+  "Maximum sticker values to keep."
+  :type 'integer
+  :group 'sly-stickers)
+```
+
+### 9.2 Selecting Contribs
+
+In user's init file:
+
+```elisp
+;; Load default "fancy" contribs
+(sly-setup '(sly-fancy))
+
+;; Or select specific contribs
+(sly-setup '(sly-mrepl sly-stickers sly-autodoc))
+
+;; Or add to existing
+(setq sly-contribs '(sly-fancy sly-my-custom-feature))
+(sly-setup sly-contribs)
+```
+
+---
+
+## 10. Contrib Directory Summary
+
+| Contrib | Elisp Lines | SLYNK Lines | Purpose |
+|---------|-------------|-------------|---------|
+| sly-fancy | 22 | - | Bundle of common contribs |
+| sly-mrepl | 1,568 | ~500 | Multiple REPLs |
+| sly-stickers | 1,358 | ~600 | Live annotations |
+| sly-trace-dialog | 743 | ~300 | Interactive tracing |
+| sly-package-fu | 448 | ~100 | Package utilities |
+| sly-fontifying-fu | 206 | - | Enhanced highlighting |
+| sly-autodoc | 188 | (arglists) | Auto documentation |
+| sly-profiler | 155 | ~200 | Profiling UI |
+| sly-tramp | 123 | - | Remote Lisp |
+| sly-fancy-trace | 68 | - | Enhanced tracing |
+| sly-scratch | 45 | - | Scratch buffer |
+| sly-indentation | 31 | ~150 | Dynamic indentation |
+| sly-fancy-inspector | 22 | ~1,300 | Rich inspection |
+| sly-retro | 22 | 45 | SLIME compat |
+
+---
+
+*Document generated from SLY source code analysis. Last updated: 2025.*

--- a/doc/PROBLEMS-AND-IMPROVEMENTS.md
+++ b/doc/PROBLEMS-AND-IMPROVEMENTS.md
@@ -1,0 +1,571 @@
+# SLY: Problems and Improvement Opportunities
+
+This document provides a critical analysis of SLY's codebase, identifying architectural issues, technical debt, and opportunities for improvement. It is intended for developers considering contributing to SLY or understanding its limitations.
+
+---
+
+## Executive Summary
+
+SLY is a mature, functional IDE that has evolved organically from SLIME since 2014. While it works well for most users, the codebase shows signs of age:
+
+- **Monolithic core** - 7,500+ lines in a single file
+- **Technical debt** - Many FIXMEs and TODOs acknowledged but not addressed
+- **Inconsistent abstractions** - Some areas are over-engineered, others under-abstracted
+- **Limited test coverage** - Many complex features lack tests
+- **Documentation gaps** - Protocol and internals poorly documented (until now)
+
+---
+
+## 1. Architectural Issues
+
+### 1.1 Monolithic sly.el
+
+**Problem:** The main `sly.el` file contains 7,511 lines covering:
+- Connection management
+- RPC layer
+- Compilation
+- Evaluation
+- Definition navigation
+- Documentation
+- Macroexpansion
+- Debugger (SLY-DB)
+- Inspector
+- Contrib system
+- Utilities
+
+**Impact:**
+- Difficult to navigate and understand
+- Changes in one area can unexpectedly affect others
+- Load time increased by loading everything
+- Testing individual components is harder
+
+**Recommendation:** Split into focused modules:
+```
+sly-core.el        # Fundamental types and utilities
+sly-connection.el  # Connection management
+sly-rpc.el         # RPC layer
+sly-compile.el     # Compilation
+sly-eval.el        # Evaluation
+sly-debug.el       # SLY-DB
+sly-inspect.el     # Inspector
+sly-xref.el        # Cross-references
+```
+
+### 1.2 Global State Management
+
+**Problem:** Heavy reliance on global variables and dynamic binding:
+
+```elisp
+;; Global connection state
+(defvar sly-net-processes nil)
+(defvar sly-default-connection nil)
+
+;; Buffer-local connection (easily out of sync)
+(defvar-local sly-buffer-connection nil)
+
+;; Implicit global state
+(defvar sly-rex-continuations nil)  ; Per-connection but accessed globally
+```
+
+**Impact:**
+- Race conditions with multiple connections
+- Confusing to determine which connection a buffer uses
+- Makes testing difficult
+
+**Recommendation:**
+- Encapsulate connection state in explicit objects
+- Pass connections explicitly rather than relying on dynamic scope
+- Consider using Emacs 29+ `slot` for structured data
+
+### 1.3 Protocol Underspecification
+
+**Problem:** The SLYNK protocol is not formally specified. Message types and their semantics are only discoverable by reading code.
+
+```elisp
+;; From sly.el - protocol is embedded in dispatch logic
+(sly-dcase event
+  ((:return value id) ...)
+  ((:debug thread level condition restarts frames conts) ...)
+  ;; etc - 25+ message types
+```
+
+**Impact:**
+- Difficult to implement alternative clients
+- Protocol changes can break compatibility silently
+- No way to validate messages
+
+**Recommendation:**
+- Create formal protocol specification (now done in SLYNK-PROTOCOL.md)
+- Consider adding protocol version negotiation
+- Add message validation on both ends
+
+### 1.4 Threading Model Complexity
+
+**Problem:** SLYNK supports four different communication styles with different threading models:
+
+```lisp
+(defvar *communication-style* :spawn
+  "Style of communication: :spawn, :sigio, :fd-handler, or nil")
+```
+
+Each style requires different code paths throughout the server.
+
+**Impact:**
+- Code duplication and conditional branches everywhere
+- Some styles are poorly tested
+- Bugs may appear in one style but not others
+
+**Recommendation:**
+- Consider dropping rarely-used styles (:sigio, :fd-handler)
+- Or abstract differences behind a cleaner interface
+
+---
+
+## 2. Technical Debt
+
+### 2.1 Documented FIXMEs and TODOs
+
+The codebase contains 50+ FIXME/TODO comments. Key ones:
+
+| Location | Issue |
+|----------|-------|
+| sly.el:142 | Contrib setup contract unclear |
+| sly.el:2841 | Dead code suspected |
+| sly.el:3037 | Questionable design |
+| sly.el:3328-3329 | Messy code needs cleanup |
+| sly.el:4554 | Unfinished feature |
+| sly.el:4991 | Recompilation cruft |
+| slynk.lisp:721 | Overdesigned |
+| slynk.lisp:1590 | Not thread safe |
+| slynk.lisp:2279 | 45 lines for simple task |
+| lib/sly-parse.el:72 | Should use syntax-ppss |
+
+### 2.2 Backward Compatibility Cruft
+
+**Problem:** Code maintains compatibility with very old Emacs versions:
+
+```elisp
+(eval-and-compile
+  (if (version< emacs-version "24.5")
+      (error "Sly requires at least Emacs 24.5")))
+```
+
+Emacs 24.5 was released in 2015. SLY could safely require Emacs 27+ now.
+
+**Impact:**
+- Cannot use modern Emacs features
+- Extra code for compatibility shims
+- Workarounds for bugs fixed in newer Emacs
+
+**Recommendation:** Bump minimum version to Emacs 27.1 (2020) or 28.1 (2022).
+
+### 2.3 Dead or Orphaned Code
+
+**Problem:** Comments suggest dead code exists:
+
+```elisp
+;; sly.el:2841
+;; FIXME: I doubt that anybody uses this directly and it seems to be
+```
+
+**Recommendation:** Audit and remove unused functions.
+
+### 2.4 Copy-Paste Duplication
+
+**Problem:** Similar patterns repeated across contribs:
+
+```elisp
+;; In multiple contribs:
+(:on-load
+ (add-hook 'sly-connected-hook '...)
+ (add-hook 'sly-mode-hook '...))
+(:on-unload
+ (remove-hook 'sly-connected-hook '...)
+ (remove-hook 'sly-mode-hook '...))
+```
+
+**Recommendation:** Create macros/helpers for common contrib patterns.
+
+---
+
+## 3. Security Issues
+
+### 3.1 Network Exposure
+
+**From PROBLEMS.md:**
+> The `M-x sly` command has Lisp listen on a TCP socket... If someone else were to connect to this socket then they could use the SLY protocol to control the Lisp process.
+
+**Current mitigations:**
+- Bind to loopback only
+- Optional secret file (`~/.sly-secret`)
+
+**Remaining issues:**
+- Secret is transmitted in plaintext
+- No TLS/encryption support
+- No authentication handshake timeout (fixed but implementation varies)
+
+**Recommendation:**
+- Document security best practices prominently
+- Consider adding TLS support for non-localhost connections
+- Add proper authentication with timeout by default
+
+### 3.2 Code Execution Risk
+
+SLYNK allows arbitrary code execution by design. Any client that can connect can:
+- Execute arbitrary Lisp code
+- Read/write files
+- Kill processes
+- Access network
+
+**Recommendation:**
+- Consider adding sandboxing options
+- Allow restricting available operations
+- Log all remote evaluations
+
+---
+
+## 4. Usability Issues
+
+### 4.1 Error Messages
+
+**Problem:** Error messages often lack context:
+
+```elisp
+(error "No SLY connection")
+```
+
+**Better:**
+```elisp
+(error "No SLY connection for buffer %s. Use M-x sly to start one."
+       (buffer-name))
+```
+
+### 4.2 Startup Complexity
+
+**Problem:** Multiple ways to start SLY with different behaviors:
+
+- `M-x sly` - Start Lisp, connect
+- `M-x sly-connect` - Connect to running server
+- `sly-setup` - Configure contribs
+
+Users often confused about which to use.
+
+**Recommendation:**
+- Simplify startup flow
+- Add guided setup wizard
+- Better first-run experience
+
+### 4.3 Keybinding Conflicts
+
+**Problem:** SLY uses `C-c` prefix extensively, conflicting with:
+- `comint-mode` bindings
+- User customizations
+- Other packages
+
+**Recommendation:**
+- Document all keybindings in one place
+- Provide easy customization via keymap variable
+- Consider using `C-c s` prefix for all SLY commands
+
+---
+
+## 5. Backend-Specific Issues
+
+### 5.1 Implementation Matrix Gaps
+
+From PROBLEMS.md and code analysis:
+
+| Issue | Affected Backends |
+|-------|-------------------|
+| Threading limitations | CLISP |
+| Weak debugging | ABCL, ECL, CLISP |
+| Slow interrupts | Allegro CL |
+| Unicode issues | LispWorks |
+| Hangs on Windows | LispWorks |
+| Arglist names wrong | CLISP |
+| `READ-CHAR-NO-HANG` broken | All |
+| Source location granularity | SBCL (without debug 2) |
+
+### 5.2 Backend Code Duplication
+
+**Problem:** Each backend reimplements similar functionality:
+
+```lisp
+;; Same pattern in sbcl.lisp, ccl.lisp, cmucl.lisp, etc.
+(defimplementation frame-source-location (index)
+  ;; Implementation-specific code to find source location
+  ...)
+```
+
+Some backends have 2000+ lines with significant duplication.
+
+**Recommendation:**
+- Extract common patterns into slynk-backend.lisp
+- Provide default implementations where possible
+- Create shared test suite for backends
+
+---
+
+## 6. Testing Deficiencies
+
+### 6.1 Coverage Gaps
+
+**Tested:**
+- Basic connection
+- Evaluation
+- Some completion
+- Indentation
+
+**Untested or undertested:**
+- Multi-connection scenarios
+- Debugger (SLY-DB) interactions
+- Inspector
+- Stickers
+- Trace dialog
+- Error recovery
+- Threading edge cases
+
+### 6.2 Test Infrastructure Issues
+
+```elisp
+;; lib/sly-tests.el:1314
+;; FIXME: suboptimal: wait one second for the lisp
+
+;; lib/sly-tests.el:1144
+;; FIXME: sly-wait-condition returns immediately if the test returns true
+```
+
+**Problems:**
+- Flaky timing-dependent tests
+- No CI matrix for multiple Lisp implementations
+- Tests require manual setup
+
+### 6.3 Recommendations
+
+- Add integration tests for major features
+- Set up CI for multiple backends (SBCL, CCL, ECL at minimum)
+- Add property-based testing for protocol
+- Create mock server for Emacs-side testing
+
+---
+
+## 7. Documentation Deficiencies
+
+### 7.1 Current State
+
+- `sly.texi` - User manual (good but incomplete)
+- `PROBLEMS.md` - Known issues (brief)
+- Code comments - Inconsistent
+- API documentation - Minimal
+
+### 7.2 Missing Documentation
+
+- Protocol specification (now created)
+- Architecture overview (now created)
+- Contrib development guide (now created)
+- Backend implementation guide
+- Debugging/troubleshooting guide
+
+### 7.3 Recommendations
+
+- ✅ Create protocol documentation (SLYNK-PROTOCOL.md)
+- ✅ Create architecture documentation (SLY-ARCHITECTURE.md)
+- ✅ Create contrib guide (CONTRIB-ARCHITECTURE.md)
+- Add inline documentation standards
+- Generate API reference from docstrings
+
+---
+
+## 8. Modernization Opportunities
+
+### 8.1 Emacs Features Not Used
+
+SLY could benefit from modern Emacs features:
+
+| Feature | Since | Benefit |
+|---------|-------|---------|
+| `seq.el` | 25.1 | Cleaner sequence operations |
+| `map.el` | 25.1 | Cleaner map operations |
+| `subr-x.el` | 24.4 | String utilities |
+| Native JSON | 27.1 | Faster parsing |
+| Native threads | 26.1 | Background operations |
+| Project.el | 26.1 | Project detection |
+| Tab-bar | 27.1 | UI organization |
+| `shortdoc.el` | 28.1 | Function groups |
+
+### 8.2 LSP Integration
+
+**Current state:** SLY predates LSP and uses its own protocol.
+
+**Opportunity:** Create LSP adapter for:
+- IDE integration (VSCode, etc.)
+- Standard tooling
+- Wider ecosystem
+
+**Challenge:** SLYNK protocol is richer than LSP for Lisp-specific features.
+
+### 8.3 Tree-sitter Support
+
+Emacs 29 includes tree-sitter. Benefits:
+- Faster, more accurate parsing
+- Better syntax highlighting
+- Improved navigation
+
+**Challenge:** No Common Lisp grammar exists for tree-sitter yet.
+
+---
+
+## 9. Performance Issues
+
+### 9.1 Completion Latency
+
+**Problem:** Completion can be slow with large symbol sets.
+
+```elisp
+;; lib/sly-completion.el:375
+;;; TODO: Most of the stuff emulates `completion--in-region'
+```
+
+**Recommendation:**
+- Implement incremental completion
+- Cache completion results
+- Use scoring/ranking to limit results
+
+### 9.2 Large Output Handling
+
+**Problem:** Large output from Lisp can freeze Emacs.
+
+**Recommendation:**
+- Implement output pagination
+- Add configurable limits
+- Stream output asynchronously
+
+### 9.3 Connection Startup
+
+**Problem:** Initial connection setup loads many modules.
+
+**Recommendation:**
+- Lazy-load less common features
+- Profile and optimize startup sequence
+- Add connection caching
+
+---
+
+## 10. Contrib-Specific Issues
+
+### 10.1 sly-stickers
+
+**Issues:**
+- Zombie sticker tracking is complex
+- Instrumentation can affect performance
+- Limited to compile-time annotation
+
+### 10.2 sly-trace-dialog
+
+**Issues:**
+- Large traces consume memory
+- No export format
+- Tree rendering slow for deep traces
+
+### 10.3 sly-mrepl
+
+**Issues:**
+- History management could be better
+- No persistent history across sessions
+- Input editing limited compared to eshell
+
+---
+
+## 11. Improvement Roadmap
+
+### Short-term (Low effort, high impact)
+
+1. ✅ Document protocol (completed)
+2. ✅ Document architecture (completed)
+3. Fix critical FIXMEs (20+ identified)
+4. Bump minimum Emacs version
+5. Improve error messages
+
+### Medium-term (Moderate effort)
+
+1. Split sly.el into focused modules
+2. Add comprehensive tests
+3. Set up CI for multiple backends
+4. Modernize using Emacs 27+ features
+5. Document backend implementation
+
+### Long-term (Significant effort)
+
+1. LSP adapter
+2. Tree-sitter support
+3. TLS/security improvements
+4. Performance optimization
+5. Protocol versioning
+
+---
+
+## 12. Conclusion
+
+SLY is a powerful, well-designed IDE that has served the Common Lisp community well. Its core architecture is sound, but a decade of evolution has left technical debt. The main priorities for improvement are:
+
+1. **Documentation** - Making the codebase accessible to new contributors
+2. **Testing** - Ensuring reliability across configurations
+3. **Modernization** - Using current Emacs capabilities
+4. **Modularization** - Breaking up the monolith
+
+The codebase is maintainable and the original design decisions (protocol, contrib system, backend abstraction) remain valid. With targeted investment, SLY can continue to be the premier Common Lisp IDE for another decade.
+
+---
+
+## Appendix: FIXME/TODO Index
+
+| File | Line | Issue |
+|------|------|-------|
+| sly.el | 142 | Contract should be like hypothetical sly-refresh-contribs |
+| sly.el | 209 | Forward reference to sly-editing-mode |
+| sly.el | 1373 | load-server & start-server separation |
+| sly.el | 2077 | Sync with sly-buffer-name |
+| sly.el | 2540 | Force inhibit-quit |
+| sly.el | 2745 | Workaround for gh#183 |
+| sly.el | 2841 | Dead code suspected |
+| sly.el | 3037 | Questionable design |
+| sly.el | 3328-3329 | Messy code, wrong location for check |
+| sly.el | 3980 | Group symbols in apropos |
+| sly.el | 4238 | Could use rename-buffer |
+| sly.el | 4554 | Unfinished TODO |
+| sly.el | 4744 | Button options |
+| sly.el | 4991-4993 | Recompilation cruft, going to contrib |
+| sly.el | 5425 | Could avoid eval in Emacs 25+ |
+| sly.el | 6710 | Why narrow buffer? |
+| sly.el | 6844 | Restore old version |
+| sly.el | 6964 | Tricky Slynk calls in contrib enable |
+| sly.el | 7127 | Similar to sly-alistify |
+| sly.el | 7282-7283 | Let it crash, bogus constraint |
+| lib/sly-tests.el | 219 | Recursive-edit issue |
+| lib/sly-tests.el | 232 | Unused function |
+| lib/sly-tests.el | 1144 | sly-wait-condition returns immediately |
+| lib/sly-tests.el | 1314 | Wait one second suboptimal |
+| lib/sly-tests.el | 1395 | Additional useful test |
+| lib/sly-completion.el | 375-382 | Emulates completion--in-region |
+| lib/sly-parse.el | 72 | Should use syntax-ppss |
+| contrib/sly-fontifying-fu.el | 33 | Remove sly-search-suppressed-forms |
+| slynk/slynk-rpc.lisp | 159 | Tell Emacs about encoding problem |
+| slynk/slynk.lisp | 496 | Fugly, need for naming |
+| slynk/slynk.lisp | 511 | Should incorporate more |
+| slynk/slynk.lisp | 721 | Overdesigned |
+| slynk/slynk.lisp | 730 | Access global variable |
+| slynk/slynk.lisp | 810 | Confusing docstring |
+| slynk/slynk.lisp | 1418 | Make use SLYNK-MATCH |
+| slynk/slynk.lisp | 1590 | Not thread safe |
+| slynk/slynk.lisp | 1798 | Deal with #\| portably |
+| slynk/slynk.lisp | 2279 | 45 lines for simple task |
+| slynk/slynk.lisp | 2380 | Check FORM for setfability |
+| slynk/slynk.lisp | 2556 | Proper method-combination |
+| slynk/slynk.lisp | 2692 | (last (compute-restarts)) dubious |
+| slynk/slynk.lisp | 2868 | Compile-file-for-emacs-hook obsoletes this |
+| slynk/slynk.lisp | 3459 | SBCL silly reason |
+| slynk/slynk.lisp | 3478 | HACK for ENSURE-ISTATE-METADATA |
+
+---
+
+*Document generated from SLY source code analysis. Last updated: 2025.*

--- a/doc/SLY-ARCHITECTURE.md
+++ b/doc/SLY-ARCHITECTURE.md
@@ -1,0 +1,845 @@
+# SLY Architecture
+
+This document provides a comprehensive analysis of SLY's architecture, covering both the Emacs client and the SLYNK server components.
+
+## Overview
+
+SLY (Sylvester the Cat's Common Lisp IDE) is a fork of SLIME that provides an integrated development environment for Common Lisp within Emacs. The architecture follows a client-server model:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                          EMACS                                   │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │                      SLY (Elisp)                           │ │
+│  │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌───────────────┐  │ │
+│  │  │ sly.el   │ │ lib/*.el │ │ contribs │ │ Mode Buffers  │  │ │
+│  │  │ (core)   │ │(utilities)│ │ sly-*.el │ │ (SLY-DB, etc) │  │ │
+│  │  └────┬─────┘ └──────────┘ └──────────┘ └───────────────┘  │ │
+│  │       │                                                     │ │
+│  │       │ TCP/IP (port 4005)                                  │ │
+│  └───────┼─────────────────────────────────────────────────────┘ │
+└──────────┼──────────────────────────────────────────────────────┘
+           │
+           │ SLYNK Protocol (S-expressions over TCP)
+           │
+┌──────────┼──────────────────────────────────────────────────────┐
+│          ▼                                                       │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │                    SLYNK (Common Lisp)                      │ │
+│  │  ┌──────────────┐ ┌─────────────────┐ ┌──────────────────┐  │ │
+│  │  │ slynk.lisp   │ │ slynk-backend   │ │ Backend Impl     │  │ │
+│  │  │ (core)       │ │ (abstraction)   │ │ (sbcl.lisp, etc) │  │ │
+│  │  └──────────────┘ └─────────────────┘ └──────────────────┘  │ │
+│  │                                                              │ │
+│  │  ┌──────────────────────────────────────────────────────┐   │ │
+│  │  │              Lisp Implementation Runtime              │   │ │
+│  │  │               (SBCL, CCL, ABCL, etc.)                │   │ │
+│  │  └──────────────────────────────────────────────────────┘   │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+│                       Common Lisp Process                        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 1. Directory Structure
+
+```
+sly/
+├── sly.el                 # Main entry point (7,511 lines)
+├── sly-autoloads.el       # Autoload definitions
+├── Makefile               # Build automation
+│
+├── lib/                   # Core Elisp utilities
+│   ├── sly-common.el      # Shared utilities (76 lines)
+│   ├── sly-messages.el    # Echo area messaging (137 lines)
+│   ├── sly-buttons.el     # Interactive button UI (355 lines)
+│   ├── sly-completion.el  # Completion framework (806 lines)
+│   ├── sly-parse.el       # S-expression parsing (355 lines)
+│   ├── sly-cl-indent.el   # CL indentation (1,885 lines)
+│   ├── sly-tests.el       # Test framework (1,545 lines)
+│   └── hyperspec.el       # HyperSpec lookup (2,630 lines)
+│
+├── slynk/                 # Common Lisp server
+│   ├── slynk.lisp         # Main server (4,236 lines)
+│   ├── slynk-backend.lisp # Backend interface (1,400+ lines)
+│   ├── slynk-rpc.lisp     # Wire protocol (212 lines)
+│   ├── slynk-match.lisp   # Pattern matching (244 lines)
+│   ├── slynk-completion.lisp  # Completion (565 lines)
+│   ├── slynk-apropos.lisp # Symbol search (240 lines)
+│   ├── slynk-gray.lisp    # Gray streams (240 lines)
+│   ├── slynk-source-path-parser.lisp  # Source parsing (246 lines)
+│   ├── slynk-source-file-cache.lisp   # File caching (134 lines)
+│   ├── xref.lisp          # Cross-references (2,904 lines)
+│   ├── metering.lisp      # Profiling support (1,530 lines)
+│   ├── slynk.asd          # ASDF system definition
+│   ├── slynk-loader.lisp  # Legacy loader (380+ lines)
+│   └── backend/           # Implementation-specific code
+│       ├── sbcl.lisp      # SBCL backend (2,024 lines)
+│       ├── ccl.lisp       # Clozure CL (874 lines)
+│       ├── abcl.lisp      # Armed Bear CL (1,530 lines)
+│       ├── cmucl.lisp     # CMU CL (2,483 lines)
+│       ├── allegro.lisp   # Allegro CL (1,115 lines)
+│       ├── lispworks.lisp # LispWorks (1,033 lines)
+│       ├── ecl.lisp       # ECL (1,093 lines)
+│       ├── clisp.lisp     # CLISP (921 lines)
+│       ├── clasp.lisp     # Clasp (737 lines)
+│       ├── scl.lisp       # Scieneer CL (1,726 lines)
+│       ├── mkcl.lisp      # ManKai CL (934 lines)
+│       └── corman.lisp    # Corman Lisp (583 lines)
+│
+├── contrib/               # Optional features
+│   ├── sly-mrepl.el       # Multiple REPLs (1,568 lines)
+│   ├── sly-stickers.el    # Live annotations (1,358 lines)
+│   ├── sly-trace-dialog.el    # Trace browser (743 lines)
+│   ├── slynk-mrepl.lisp   # MREPL server-side (500+ lines)
+│   ├── slynk-stickers.lisp    # Sticker server (600+ lines)
+│   └── ... (more contribs)
+│
+├── test/                  # Test suite
+│   ├── sly-*-tests.el     # Feature tests
+│   └── sly-cl-indent-test.txt  # Indentation tests
+│
+└── doc/                   # Documentation
+    ├── sly.texi           # Texinfo manual
+    └── images/            # Screenshots
+```
+
+---
+
+## 2. Emacs Side Architecture
+
+### 2.1 Core Module: sly.el
+
+The main `sly.el` file (7,511 lines) is organized into these major sections:
+
+| Section | Lines | Purpose |
+|---------|-------|---------|
+| Header & Dependencies | 1-110 | Package declaration, requires |
+| Customization | 111-400 | User-facing options |
+| Keymaps & Modes | 401-700 | Mode definitions, keybindings |
+| Starting SLY | 701-1000 | Process startup, initialization |
+| Networking | 1001-1750 | TCP connections, protocol |
+| Connections | 1751-2250 | Connection state management |
+| RPC Interface | 2251-2700 | Remote procedure calls |
+| Compilation | 2701-3500 | Compiler notes, warnings |
+| Evaluation | 3501-4000 | Interactive evaluation |
+| Definition Navigation | 4001-4500 | Edit-definition, XREF |
+| Documentation | 4501-5000 | Docstrings, describe |
+| Macroexpansion | 5001-5300 | Macro expansion UI |
+| SLY-DB (Debugger) | 5301-6400 | Debugger interface |
+| Inspector | 6401-6900 | Object inspection |
+| Contrib System | 6901-7100 | Contrib loading |
+| Utilities | 7101-7511 | Helper functions |
+
+### 2.2 Major Subsystems
+
+#### 2.2.1 Connection Management
+
+```elisp
+;; Connection structure (sly.el:1751-1850)
+(cl-defstruct (sly-connection (:conc-name sly-connection.))
+  process                  ; Network process
+  id                       ; Unique connection ID
+  name                     ; Display name
+  coding-system            ; Character encoding
+  server-implementation    ; Lisp implementation info
+  pid                      ; Remote process ID
+  rex-continuations        ; Pending RPC callbacks
+  channels                 ; Active channels
+  ...)
+```
+
+**Key variables:**
+- `sly-net-processes` - List of active network processes
+- `sly-default-connection` - Current default connection
+- `sly-buffer-connection` - Buffer-local connection
+
+**Connection lifecycle:**
+1. `sly` / `sly-connect` - Initiate connection
+2. `sly-net-connect` - Establish TCP socket
+3. `sly-setup-connection` - Configure connection
+4. `sly-init-connection` - Exchange capabilities
+5. `sly-net-close` - Terminate connection
+
+#### 2.2.2 RPC Layer
+
+```elisp
+;; Synchronous evaluation
+(defun sly-eval (sexp &optional package)
+  "Evaluate SEXP in Lisp and return the result."
+  (let ((result (sly-eval-async sexp #'identity package)))
+    (while (not result)
+      (accept-process-output))
+    result))
+
+;; Asynchronous evaluation
+(defun sly-eval-async (sexp &optional cont package)
+  "Evaluate SEXP in Lisp. Call CONT with result when done."
+  (sly-dispatch-event
+   `(:emacs-rex ,sexp ,(or package (sly-current-package))
+                ,(or (sly-current-thread) t)
+                ,cont)))
+```
+
+#### 2.2.3 SLY-DB (Debugger)
+
+The debugger is a major-mode derived from `special-mode`:
+
+```elisp
+(define-derived-mode sly-db-mode special-mode "SLY-DB"
+  "Mode for debugging Common Lisp conditions."
+  (setq-local truncate-lines t)
+  (setq-local sly-db-level nil)
+  ...)
+```
+
+**Buffer structure:**
+```
+Condition: DIVISION-BY-ZERO
+  [Condition details...]
+
+Restarts:
+  0: [ABORT] Return to REPL
+  1: [CONTINUE] Use a value
+  ...
+
+Backtrace:
+  0: (/ 1 0)
+  1: (EVAL (/ 1 0))
+  ...
+```
+
+**Key commands:**
+- `q` - Quit (abort)
+- `c` - Continue
+- `0-9` - Invoke restart by number
+- `v` - View frame source
+- `e` - Eval in frame
+- `i` - Inspect in frame
+
+#### 2.2.4 Inspector
+
+Object inspection UI:
+
+```elisp
+(define-derived-mode sly-inspector-mode special-mode "SLY-Inspector"
+  "Mode for inspecting Lisp objects."
+  ...)
+```
+
+**Buffer structure:**
+```
+#<HASH-TABLE :TEST EQL :COUNT 3>
+--------------------
+Type: HASH-TABLE
+Count: 3
+Size: 16
+Rehash-size: 1.5
+Rehash-threshold: 1.0
+
+[Contents]
+  :A -> 1
+  :B -> 2
+  :C -> 3
+```
+
+### 2.3 Library Modules (lib/)
+
+#### 2.3.1 sly-completion.el
+
+Provides completion backend supporting multiple frontends:
+
+```elisp
+;; Completion table function
+(defun sly--completion-function (string pred action)
+  (pcase action
+    ('metadata ...)       ; Metadata about completions
+    ('t ...)              ; All completions
+    ('nil ...)            ; Try-completion
+    ((pred functionp) ...)  ; Lambda action
+    ...))
+```
+
+**Supported frontends:**
+- Vanilla Emacs completion
+- Company-mode
+- Helm
+- Ivy
+
+#### 2.3.2 sly-buttons.el
+
+Creates interactive buttons in SLY buffers:
+
+```elisp
+(define-button-type 'sly-part
+  'action 'sly-button-action
+  'mouse-action 'sly-button-action
+  'sly-button-search-id nil
+  ...)
+```
+
+Used for clickable objects in:
+- Inspector values
+- REPL output
+- Debugger frames
+
+#### 2.3.3 sly-parse.el
+
+S-expression aware parsing:
+
+```elisp
+(defun sly-parse-form-until (position)
+  "Parse form from buffer start to POSITION."
+  ...)
+
+(defun sly-parse-context ()
+  "Return context around point for autodoc."
+  ...)
+```
+
+#### 2.3.4 sly-cl-indent.el
+
+Enhanced Common Lisp indentation (forked from Emacs's cl-indent.el):
+
+- Loop clause alignment
+- Backquote handling
+- Custom indentation specs per symbol
+- Package-qualified symbol support
+
+---
+
+## 3. SLYNK Side Architecture
+
+### 3.1 Package Structure
+
+```lisp
+;; Core packages
+:slynk              ; Main server package
+:slynk-backend      ; Implementation abstraction
+:slynk-rpc          ; Wire protocol
+:slynk-mop          ; CLOS introspection portability
+:slynk-match        ; Pattern matching for completion
+:slynk-completion   ; Completion algorithms
+:slynk-apropos      ; Symbol search
+:slynk-io-package   ; Clean namespace for protocol I/O
+```
+
+### 3.2 Core Server (slynk.lisp)
+
+#### 3.2.1 Server Startup
+
+```lisp
+(defun create-server (&key (port default-server-port)
+                           (style *communication-style*)
+                           (dont-close nil))
+  "Create a SLYNK server listening on PORT."
+  (setup-server port
+                (lambda (socket)
+                  (accept-authenticated-connection socket))
+                style
+                dont-close))
+```
+
+**Communication styles:**
+| Style | Threading Model | Use Case |
+|-------|-----------------|----------|
+| `:spawn` | Full multithreading | Default for threaded Lisps |
+| `:sigio` | Signal-based I/O | Single-threaded alternative |
+| `:fd-handler` | FD handler callbacks | Event loop integration |
+| `nil` | Polling | Simplest, most portable |
+
+#### 3.2.2 Connection Handling
+
+```lisp
+(defstruct (connection (:constructor %make-connection))
+  socket                    ; TCP socket
+  socket-io                 ; I/O stream
+  (channel-counter 0)       ; Channel ID generator
+  (channels '())            ; Active channels
+  (listeners '())           ; Event listeners
+  (inspectors '())          ; Inspector state
+  indentation-cache         ; Symbol indentation info
+  communication-style)      ; Threading model
+
+(defstruct (multithreaded-connection (:include connection))
+  reader-thread            ; Network reader
+  control-thread           ; Event dispatcher
+  auto-flush-thread        ; Output flusher
+  (active-threads '()))    ; Worker threads
+
+(defstruct (singlethreaded-connection (:include connection))
+  (event-queue '())        ; Pending events
+  (events-enqueued 0))     ; Event counter
+```
+
+#### 3.2.3 Event Loop
+
+**Multithreaded:**
+```lisp
+(defun read-loop (connection)
+  "Read messages from socket, send to control thread."
+  (let ((input-stream (connection-socket-io connection)))
+    (with-slynk-error-handler (connection)
+      (loop (send control-thread (decode-message input-stream))))))
+
+(defun dispatch-loop (connection)
+  "Receive events from reader, dispatch to handlers."
+  (let ((*emacs-connection* connection))
+    (with-panic-handler (connection)
+      (loop (dispatch-event connection (receive))))))
+```
+
+**Event dispatch:**
+```lisp
+(defun dispatch-event (connection event)
+  (destructure-case event
+    ((:emacs-rex form package thread-id id &rest extra)
+     (spawn-worker-for-request connection form package thread-id id extra))
+    ((:return thread &rest args)
+     (encode-message `(:return ,@args) (current-socket-io)))
+    ((:emacs-interrupt thread-id)
+     (interrupt-worker connection thread-id))
+    ...))
+```
+
+#### 3.2.4 RPC Function Definition
+
+```lisp
+(defmacro defslyfun (name arglist &body body)
+  "Define a function callable from Emacs via RPC."
+  `(progn
+     (defun ,name ,arglist ,@body)
+     (export ',name :slynk)))
+```
+
+**Examples:**
+```lisp
+(defslyfun connection-info ()
+  "Return version and implementation info."
+  `(:pid ,(getpid)
+    :lisp-implementation (:type ,(lisp-implementation-type)
+                          :version ,(lisp-implementation-version))
+    :machine (:type ,(machine-type))
+    :features ,(features-for-emacs)
+    :package ,(package-name *package*)
+    :version ,*slynk-wire-protocol-version*))
+
+(defslyfun interactive-eval (string)
+  "Evaluate STRING and return result as string."
+  (with-buffer-syntax ()
+    (with-retry-restart (:msg "Retry SLY evaluation.")
+      (let ((values (multiple-value-list (eval (from-string string)))))
+        (format nil "~{~S~^~%~}" values)))))
+```
+
+### 3.3 Backend Abstraction (slynk-backend.lisp)
+
+The backend defines generic functions that must be specialized per Lisp implementation:
+
+```lisp
+(defpackage slynk-backend
+  (:use :common-lisp)
+  (:export
+   ;; Compilation
+   #:compile-string-for-emacs
+   #:compile-file-for-emacs
+
+   ;; Debugging
+   #:call-with-debugger-hook
+   #:compute-backtrace
+   #:frame-locals
+   #:frame-source-location
+   #:invoke-debugger
+
+   ;; Introspection
+   #:arglist
+   #:function-name
+   #:macroexpand-all
+   #:describe-symbol-for-emacs
+
+   ;; Source location
+   #:find-definitions
+   #:buffer-first-change
+   ...))
+
+(defmacro defimplementation (name args &body body)
+  "Define implementation-specific behavior."
+  `(defmethod ,name ,args ,@body))
+```
+
+### 3.4 Backend Implementations
+
+Each backend file specializes the generic functions:
+
+#### 3.4.1 SBCL Backend (sbcl.lisp)
+
+```lisp
+(defimplementation compute-backtrace (start end)
+  "Return backtrace frames from START to END."
+  (loop for frame in (sb-debug:list-backtrace)
+        for i from 0
+        when (and (>= i start) (or (null end) (< i end)))
+        collect (make-frame :number i
+                           :description (frame-to-string frame)
+                           :restartable (restartable-frame-p frame))))
+
+(defimplementation frame-source-location (index)
+  "Return source location for frame INDEX."
+  (let* ((frame (nth index (sb-debug:list-backtrace)))
+         (debug-fun (sb-di:frame-debug-fun frame))
+         (code-location (sb-di:frame-code-location frame)))
+    (cond ((sb-di:debug-source-namestring
+            (sb-di:code-location-debug-source code-location))
+           => (lambda (file)
+                (make-location :file file
+                              :position (safe-source-location-for-emacs code-location))))
+          (t nil))))
+```
+
+#### 3.4.2 Implementation Feature Matrix
+
+| Feature | SBCL | CCL | ABCL | ECL | CLISP |
+|---------|------|-----|------|-----|-------|
+| Threading | Full | Full | Full | Full | Limited |
+| Debugging | Full | Full | Basic | Basic | Basic |
+| Profiling | Full | Full | Basic | Basic | None |
+| CLOS Inspect | Full | Full | Full | Basic | Basic |
+| Source Locs | Full | Full | Basic | Basic | Basic |
+
+### 3.5 Cross-Reference System (xref.lisp)
+
+Provides "who calls", "who references", etc.:
+
+```lisp
+(defun who-calls (function-name)
+  "Return list of functions that call FUNCTION-NAME."
+  ...)
+
+(defun who-references (variable-name)
+  "Return list of functions that reference VARIABLE-NAME."
+  ...)
+
+(defun who-binds (variable-name)
+  "Return list of functions that bind VARIABLE-NAME."
+  ...)
+
+(defun who-sets (variable-name)
+  "Return list of functions that set VARIABLE-NAME."
+  ...)
+
+(defun who-macroexpands (macro-name)
+  "Return list of functions that expand MACRO-NAME."
+  ...)
+
+(defun who-specializes (class-name)
+  "Return methods specializing on CLASS-NAME."
+  ...)
+```
+
+---
+
+## 4. Data Flow
+
+### 4.1 Evaluation Flow
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                         EMACS                                   │
+│                                                                │
+│  User types: (+ 1 2)                                           │
+│       │                                                        │
+│       ▼                                                        │
+│  sly-eval-last-expression                                      │
+│       │                                                        │
+│       ▼                                                        │
+│  sly-eval-async '(slynk:interactive-eval "(+ 1 2)")           │
+│       │                                                        │
+│       ▼                                                        │
+│  sly-dispatch-event (:emacs-rex ...)                          │
+│       │                                                        │
+│       ▼                                                        │
+│  sly-net-send  →  TCP  →                                       │
+└───────────────────────┼────────────────────────────────────────┘
+                        │
+                        ▼
+┌───────────────────────────────────────────────────────────────┐
+│                        SLYNK                                   │
+│                                                                │
+│  decode-message                                                │
+│       │                                                        │
+│       ▼                                                        │
+│  dispatch-event (:emacs-rex ...)                              │
+│       │                                                        │
+│       ▼                                                        │
+│  spawn-worker-thread                                           │
+│       │                                                        │
+│       ▼                                                        │
+│  slynk:interactive-eval "(+ 1 2)"                             │
+│       │                                                        │
+│       ▼                                                        │
+│  (eval (from-string "(+ 1 2)"))  →  3                         │
+│       │                                                        │
+│       ▼                                                        │
+│  format result as string "3"                                   │
+│       │                                                        │
+│       ▼                                                        │
+│  send-to-emacs (:return (:ok "3") request-id)                 │
+│       │                                                        │
+│       ▼                                                        │
+│  encode-message  →  TCP  →                                     │
+└───────────────────────┼───────────────────────────────────────┘
+                        │
+                        ▼
+┌───────────────────────────────────────────────────────────────┐
+│                         EMACS                                  │
+│                                                                │
+│  sly-net-filter (receive data)                                │
+│       │                                                        │
+│       ▼                                                        │
+│  sly-dispatch-event (:return ...)                             │
+│       │                                                        │
+│       ▼                                                        │
+│  find continuation by request-id                               │
+│       │                                                        │
+│       ▼                                                        │
+│  invoke callback with "3"                                      │
+│       │                                                        │
+│       ▼                                                        │
+│  Display "3" in echo area                                      │
+└───────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Debugger Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  SLYNK: Error occurs during evaluation                      │
+│                                                             │
+│  invoke-slynk-debugger                                      │
+│       │                                                     │
+│       ▼                                                     │
+│  Compute condition info, restarts, backtrace               │
+│       │                                                     │
+│       ▼                                                     │
+│  send-to-emacs (:debug thread level condition restarts ...) │
+│  send-to-emacs (:debug-activate thread level)              │
+│       │                                                     │
+│       ▼                                                     │
+│  Wait for debug commands...                                 │
+└──────────────────────────┼──────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  EMACS: Receive debug events                                │
+│                                                             │
+│  sly-dispatch-event (:debug ...)                           │
+│       │                                                     │
+│       ▼                                                     │
+│  Create *sly-db* buffer                                    │
+│  Display condition, restarts, backtrace                    │
+│       │                                                     │
+│  User presses '0' (invoke restart 0)                       │
+│       │                                                     │
+│       ▼                                                     │
+│  sly-db-invoke-restart 0                                   │
+│       │                                                     │
+│       ▼                                                     │
+│  (:emacs-rex (slynk:invoke-nth-restart-for-emacs ...) ...)│
+└──────────────────────────┼──────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  SLYNK: Process restart command                            │
+│                                                             │
+│  invoke-nth-restart-for-emacs                              │
+│       │                                                     │
+│       ▼                                                     │
+│  invoke-restart (nth restarts n)                           │
+│       │                                                     │
+│       ▼                                                     │
+│  Control returns to appropriate point                       │
+│       │                                                     │
+│       ▼                                                     │
+│  send-to-emacs (:debug-return thread level nil)            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Initialization Sequence
+
+### 5.1 Emacs Side Startup
+
+```elisp
+;; User invokes M-x sly
+(defun sly (&optional command coding-system)
+  (interactive)
+  (let ((inferior-lisp-program (or command inferior-lisp-program)))
+    (sly-start :program inferior-lisp-program)))
+
+(defun sly-start (&key program program-args env directory coding-system)
+  ;; 1. Setup contrib system
+  (sly-setup sly-contribs)
+
+  ;; 2. Start inferior Lisp process
+  (let ((proc (sly-inferior-lisp-start program program-args env directory)))
+
+    ;; 3. Inject SLYNK loading code
+    (sly-inferior-lisp-inject-loader proc coding-system)
+
+    ;; 4. Connect when server ready
+    (sly-connect-when-server-ready proc)))
+```
+
+### 5.2 SLYNK Loading
+
+SLY injects this code into the Lisp process:
+
+```lisp
+;; Method 1: ASDF (preferred)
+(asdf:load-system :slynk)
+(slynk:create-server :port 4005)
+
+;; Method 2: Legacy loader
+(load "~/.emacs.d/elpa/sly/slynk/slynk-loader.lisp")
+(slynk-loader:init)
+(slynk:create-server :port 4005)
+```
+
+### 5.3 Connection Establishment
+
+```elisp
+(defun sly-net-connect (host port)
+  ;; 1. Open TCP connection
+  (let ((connection (open-network-stream "sly" nil host port)))
+
+    ;; 2. Setup filter for incoming data
+    (set-process-filter connection 'sly-net-filter)
+
+    ;; 3. Send secret if configured
+    (sly-send-secret connection)
+
+    ;; 4. Return connection
+    connection))
+
+(defun sly-setup-connection (connection)
+  ;; 1. Request connection info
+  (sly-eval-async '(slynk:connection-info)
+    (lambda (info)
+      ;; 2. Store server capabilities
+      (setf (sly-connection.server-implementation connection)
+            (plist-get info :lisp-implementation))
+
+      ;; 3. Load required SLYNK modules
+      (sly-contrib--load-slynk-dependencies)
+
+      ;; 4. Initialize contribs
+      (run-hooks 'sly-connected-hook))))
+```
+
+---
+
+## 6. Buffer Management
+
+### 6.1 Buffer Types
+
+| Buffer Pattern | Mode | Purpose |
+|----------------|------|---------|
+| `*sly-mrepl for ...*` | `sly-mrepl-mode` | REPL interaction |
+| `*sly-db ...*` | `sly-db-mode` | Debugger |
+| `*sly-inspector*` | `sly-inspector-mode` | Object inspection |
+| `*sly-xref*` | `sly-xref-mode` | Cross-references |
+| `*sly-description*` | `sly-description-mode` | Documentation |
+| `*sly-macroexpansion*` | `sly-macroexpansion-mode` | Macro expansion |
+| `*sly-trace-dialog*` | `sly-trace-dialog-mode` | Trace browser |
+
+### 6.2 Buffer-Connection Association
+
+```elisp
+;; Each buffer tracks its connection
+(defvar-local sly-buffer-connection nil
+  "Network connection for this buffer.")
+
+(defun sly-connection ()
+  "Return connection for current buffer."
+  (or sly-buffer-connection
+      sly-default-connection
+      (error "No SLY connection")))
+```
+
+---
+
+## 7. Key Interfaces
+
+### 7.1 Public Elisp API
+
+**Connection:**
+```elisp
+(sly)                           ; Start Lisp and connect
+(sly-connect host port)         ; Connect to running server
+(sly-disconnect)                ; Close connection
+(sly-restart-inferior-lisp)     ; Restart Lisp process
+```
+
+**Evaluation:**
+```elisp
+(sly-eval sexp &optional package)           ; Sync eval
+(sly-eval-async sexp cont &optional pkg)    ; Async eval
+(sly-interactive-eval string)               ; Eval with output
+```
+
+**Navigation:**
+```elisp
+(sly-edit-definition name)      ; Jump to definition
+(sly-pop-find-definition-stack) ; Return from definition
+(sly-who-calls name)            ; Find callers
+```
+
+**Documentation:**
+```elisp
+(sly-describe-symbol symbol)    ; Show documentation
+(sly-describe-function name)    ; Describe function
+(sly-apropos pattern)           ; Search symbols
+```
+
+### 7.2 Public SLYNK API
+
+**Server control:**
+```lisp
+(slynk:create-server &key port style dont-close)
+(slynk:stop-server port)
+```
+
+**Evaluation:**
+```lisp
+(slynk:interactive-eval string)
+(slynk:eval-and-grab-output string)
+(slynk:pprint-eval string)
+```
+
+**Introspection:**
+```lisp
+(slynk:find-definitions-for-emacs name)
+(slynk:xref type name)
+(slynk:apropos-list-for-emacs pattern)
+```
+
+---
+
+## 8. Code Statistics
+
+| Component | Files | Lines | Purpose |
+|-----------|-------|-------|---------|
+| Core Elisp | 1 | 7,511 | Main functionality |
+| Lib Elisp | 8 | ~8,000 | Utilities |
+| Contrib Elisp | 14 | ~6,600 | Optional features |
+| Core SLYNK | 10 | ~10,000 | Server |
+| Backends | 12 | ~16,000 | Implementation-specific |
+| Contrib SLYNK | 9 | ~5,500 | Server extensions |
+| Tests | 8 | ~1,500 | Test suite |
+| **Total** | **62** | **~55,000** | |
+
+---
+
+*Document generated from SLY source code analysis. Last updated: 2025.*

--- a/doc/SLYNK-PROTOCOL.md
+++ b/doc/SLYNK-PROTOCOL.md
@@ -1,0 +1,871 @@
+# SLYNK Protocol Specification
+
+This document provides an exhaustive specification of the SLYNK protocol used by SLY to communicate between Emacs and Common Lisp implementations.
+
+## Overview
+
+SLYNK (the server component of SLY) uses a text-based protocol built on S-expressions transmitted over TCP. The protocol is bidirectional, supporting both synchronous RPC (Remote Procedure Call) and asynchronous events.
+
+**Historical Note:** SLY is a fork of SLIME, and SLYNK is a fork of SWANK. The protocol remains largely compatible but has diverged in several areas, particularly around channels and the MREPL system.
+
+---
+
+## 1. Wire Format
+
+### 1.1 Message Structure
+
+Every message follows this format:
+
+```
+┌─────────────────┬──────────────────────────────────────┐
+│  6-byte header  │  UTF-8 encoded S-expression payload  │
+└─────────────────┴──────────────────────────────────────┘
+```
+
+### 1.2 Header Format
+
+The header is exactly 6 ASCII hexadecimal characters representing the byte length of the payload (not including the header itself).
+
+```
+"00001a" = 26 bytes of payload
+"000100" = 256 bytes of payload
+"ffffff" = 16,777,215 bytes (maximum message size)
+```
+
+**Encoding (Lisp side):**
+```lisp
+;; slynk-rpc.lisp:150-156
+(defun write-header (stream length)
+  (declare (type (unsigned-byte 24) length))
+  (loop for c across (format nil "~6,'0x" length)
+        do (write-byte (char-code c) stream)))
+```
+
+**Decoding (Emacs side):**
+```elisp
+;; sly.el:1719
+(defsubst sly-net-decode-length ()
+  (string-to-number (buffer-substring (point) (+ (point) 6)) 16))
+```
+
+### 1.3 Payload Format
+
+The payload is a UTF-8 encoded S-expression that must be readable by both Emacs Lisp and Common Lisp. The S-expression is a list where:
+
+- The first element (car) is a keyword identifying the message type
+- Remaining elements are message-specific arguments
+
+**Example messages:**
+```lisp
+(:emacs-rex (slynk:connection-info) "COMMON-LISP-USER" t 1)
+(:return (:ok (:pid 12345 :lisp-implementation (:type "SBCL"))) 1)
+(:write-string "Hello, world!" :repl-result)
+```
+
+### 1.4 Package Context
+
+Messages are read in the `SLYNK-IO-PACKAGE` (Lisp) or `sly-io-package` (Emacs) which provides a clean namespace for the protocol symbols.
+
+**Lisp side:**
+```lisp
+;; slynk-rpc.lisp:11-17
+(defpackage slynk-rpc
+  (:use :cl)
+  (:export ...))
+
+(defparameter *slynk-io-package*
+  (let ((p (make-package :slynk-io-package :use '())))
+    (import '(nil t quote) p)
+    p))
+```
+
+---
+
+## 2. Message Types
+
+### 2.1 Emacs → Lisp Messages
+
+These messages originate in Emacs and are sent to the SLYNK server.
+
+#### 2.1.1 `:emacs-rex` - Remote Execution Request
+
+The primary RPC mechanism. Asks Lisp to evaluate a form and return the result.
+
+```lisp
+(:emacs-rex FORM PACKAGE THREAD-ID REQUEST-ID &rest EXTRA-OPTIONS)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `FORM` | sexp | Lisp form to evaluate (typically `(slynk:function-name args...)`) |
+| `PACKAGE` | string | Package name for evaluation context |
+| `THREAD-ID` | `t` \| `:find-existing` \| integer | Target thread for evaluation |
+| `REQUEST-ID` | integer | Unique ID for correlating response |
+| `EXTRA-OPTIONS` | plist | Additional options (rarely used) |
+
+**Thread-ID values:**
+- `t` - Spawn a new worker thread
+- `:find-existing` - Use an existing active thread
+- `integer` - Target a specific thread by ID
+
+**Example:**
+```lisp
+(:emacs-rex (slynk:autodoc '("format" slynk::%cursor-marker%))
+            "COMMON-LISP-USER" t 42)
+```
+
+#### 2.1.2 `:emacs-interrupt` - Interrupt Thread
+
+Sends an interrupt signal to a running evaluation.
+
+```lisp
+(:emacs-interrupt THREAD-ID)
+```
+
+**Implementation:**
+```lisp
+;; slynk.lisp:1290
+((:emacs-interrupt thread-id)
+ (interrupt-thread connection thread-id))
+```
+
+#### 2.1.3 `:emacs-return` - Return Value to Waiting Thread
+
+Returns a value to a Lisp thread that requested input from Emacs.
+
+```lisp
+(:emacs-return THREAD-ID TAG VALUE)
+```
+
+Used when Lisp calls `slynk:eval-in-emacs` and needs a return value.
+
+#### 2.1.4 `:emacs-return-string` - Return String Input
+
+Returns user-entered string to a waiting `read-string` or `read-from-minibuffer` request.
+
+```lisp
+(:emacs-return-string THREAD-ID TAG STRING)
+```
+
+#### 2.1.5 `:emacs-pong` - Ping Response
+
+Responds to a ping from the server.
+
+```lisp
+(:emacs-pong THREAD-ID TAG)
+```
+
+#### 2.1.6 `:emacs-channel-send` - Channel Message
+
+Sends a message to a specific channel (see Section 5).
+
+```lisp
+(:emacs-channel-send CHANNEL-ID MESSAGE)
+```
+
+#### 2.1.7 `:emacs-skipped-packet` - Skipped Packet Notification
+
+Informs the server that a packet was intentionally skipped.
+
+```lisp
+(:emacs-skipped-packet PACKET)
+```
+
+### 2.2 Lisp → Emacs Messages
+
+These messages originate in the SLYNK server and are sent to Emacs.
+
+#### 2.2.1 `:return` - RPC Response
+
+Returns the result of an `:emacs-rex` request.
+
+```lisp
+(:return VALUE REQUEST-ID)
+```
+
+**VALUE formats:**
+- `(:ok RESULT)` - Successful evaluation, RESULT is the return value
+- `(:abort CONDITION)` - Evaluation aborted, CONDITION describes why
+- `(:error CONDITION)` - Error during evaluation (distinct from `:abort`)
+
+**Example:**
+```lisp
+(:return (:ok ((:label "Name:" :value "FOO"))) 42)
+(:return (:abort "User interrupt") 43)
+```
+
+#### 2.2.2 `:debug` - Enter Debugger
+
+Signals that a condition occurred and the debugger should be activated.
+
+```lisp
+(:debug THREAD-ID LEVEL CONDITION RESTARTS FRAMES CONTINUATIONS)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `THREAD-ID` | integer | Thread that triggered the condition |
+| `LEVEL` | integer | Debugger nesting level (1-based) |
+| `CONDITION` | list | `(DESCRIPTION TYPE EXTRAS...)` |
+| `RESTARTS` | list | Available restart options |
+| `FRAMES` | list | Initial backtrace frames |
+| `CONTINUATIONS` | list | Pending continuations |
+
+**CONDITION structure:**
+```lisp
+("Division by zero" "DIVISION-BY-ZERO" (:references ...))
+```
+
+**RESTARTS structure:**
+```lisp
+(("ABORT" "Return to REPL")
+ ("CONTINUE" "Return zero")
+ ("USE-VALUE" "Supply a value to use"))
+```
+
+**FRAMES structure:**
+```lisp
+((0 "(/ 1 0)" (:restartable t))
+ (1 "(EVAL (/ 1 0))" (:restartable nil))
+ ...)
+```
+
+#### 2.2.3 `:debug-activate` - Activate Debugger Display
+
+Tells Emacs to display the debugger buffer.
+
+```lisp
+(:debug-activate THREAD-ID LEVEL)
+```
+
+Sent after `:debug` when the debugger is ready for interaction.
+
+#### 2.2.4 `:debug-return` - Exit Debugger
+
+Signals that the debugger is exiting.
+
+```lisp
+(:debug-return THREAD-ID LEVEL STEPPING-P)
+```
+
+| Field | Description |
+|-------|-------------|
+| `STEPPING-P` | If non-nil, stepping through code |
+
+#### 2.2.5 `:debug-condition` - Debugger Condition
+
+Notifies about a condition in the debugger itself.
+
+```lisp
+(:debug-condition THREAD-ID MESSAGE)
+```
+
+#### 2.2.6 `:write-string` - Output Text
+
+Sends text output to be displayed.
+
+```lisp
+(:write-string STRING &optional TARGET)
+```
+
+**TARGET values:**
+- `:repl-result` - REPL result output
+- `:repl-stderr` - Standard error
+- `nil` or omitted - Standard output
+
+#### 2.2.7 `:read-string` - Request String Input
+
+Requests that Emacs read a string from the user.
+
+```lisp
+(:read-string THREAD-ID TAG)
+```
+
+Emacs responds with `:emacs-return-string`.
+
+#### 2.2.8 `:read-from-minibuffer` - Request Minibuffer Input
+
+Requests input via Emacs minibuffer.
+
+```lisp
+(:read-from-minibuffer THREAD-ID TAG PROMPT INITIAL-VALUE)
+```
+
+#### 2.2.9 `:y-or-n-p` - Yes/No Question
+
+Asks a yes-or-no question.
+
+```lisp
+(:y-or-n-p THREAD-ID TAG QUESTION)
+```
+
+#### 2.2.10 `:eval` - Evaluate in Emacs
+
+Requests Emacs to evaluate an Emacs Lisp form.
+
+```lisp
+(:eval THREAD-ID TAG FORM-STRING)
+```
+
+**Example:**
+```lisp
+(:eval 1 42 "(message \"Hello from Lisp!\")")
+```
+
+#### 2.2.11 `:eval-no-wait` - Evaluate in Emacs (No Response)
+
+Like `:eval` but doesn't wait for a response.
+
+```lisp
+(:eval-no-wait FORM-STRING)
+```
+
+#### 2.2.12 `:new-package` - Package Changed
+
+Notifies that the current package changed.
+
+```lisp
+(:new-package PACKAGE-NAME PROMPT-STRING)
+```
+
+#### 2.2.13 `:new-features` - Features List Update
+
+Sends updated `*features*` list.
+
+```lisp
+(:new-features FEATURES-LIST)
+```
+
+#### 2.2.14 `:indentation-update` - Indentation Cache Update
+
+Sends indentation information for symbols.
+
+```lisp
+(:indentation-update INDENTATION-INFO)
+```
+
+**INDENTATION-INFO format:**
+```lisp
+((symbol1 . (indent-spec1))
+ (symbol2 . (indent-spec2))
+ ...)
+```
+
+#### 2.2.15 `:ed` - Edit Location
+
+Requests Emacs to open a file/location for editing.
+
+```lisp
+(:ed WHAT)
+```
+
+**WHAT formats:**
+- String - File path
+- `(:filename PATH :position POS)` - File with position
+- `(:function NAME)` - Find function definition
+
+#### 2.2.16 `:inspect` - Open Inspector
+
+Opens the inspector on an object.
+
+```lisp
+(:inspect WHAT THREAD-ID TAG)
+```
+
+#### 2.2.17 `:ping` - Ping Request
+
+Server pings Emacs to check liveness.
+
+```lisp
+(:ping THREAD-ID TAG)
+```
+
+Emacs responds with `:emacs-pong`.
+
+#### 2.2.18 `:channel-send` - Channel Message
+
+Sends a message from a channel.
+
+```lisp
+(:channel-send CHANNEL-ID MESSAGE)
+```
+
+#### 2.2.19 `:background-message` - Background Notification
+
+Displays a message without blocking.
+
+```lisp
+(:background-message MESSAGE)
+```
+
+#### 2.2.20 `:reader-error` - Protocol Parse Error
+
+Reports a parsing error in the protocol stream.
+
+```lisp
+(:reader-error PACKET-STRING CONDITION)
+```
+
+#### 2.2.21 `:invalid-rpc` - Invalid RPC Request
+
+Reports an invalid RPC request.
+
+```lisp
+(:invalid-rpc REQUEST-ID MESSAGE)
+```
+
+#### 2.2.22 `:invalid-channel` - Invalid Channel
+
+Reports an error with a channel.
+
+```lisp
+(:invalid-channel CHANNEL-ID REASON)
+```
+
+---
+
+## 3. RPC Mechanism
+
+### 3.1 Request-Response Correlation
+
+Each RPC request has a unique integer ID. Responses include this ID for correlation.
+
+**Emacs side (sly.el:2328-2340):**
+```elisp
+(defun sly-dispatch-event (event &optional process)
+  (sly-dcase event
+    ((:emacs-rex form package thread continuation &rest extra-options)
+     (when (and (sly-use-sigint-for-interrupt) (sly-busy-p))
+       (sly-display-oneliner "; pipelined request... %S" form))
+     (let ((id (cl-incf (sly-continuation-counter))))
+       (sly-send `(:emacs-rex ,form ,package ,thread ,id ,@extra-options))
+       (push (cons id continuation) (sly-rex-continuations))))
+
+    ((:return value id)
+     (let ((rec (assq id (sly-rex-continuations))))
+       (cond (rec (setf (sly-rex-continuations)
+                        (remove rec (sly-rex-continuations)))
+                  (funcall (cdr rec) value))
+             (t (error "Unexpected reply: %S %S" id value)))))))
+```
+
+### 3.2 Continuation Storage
+
+Pending requests are stored in `sly-rex-continuations`, an alist of `(ID . CALLBACK)`.
+
+### 3.3 Synchronous vs Asynchronous Evaluation
+
+**Asynchronous (sly-eval-async):**
+```elisp
+(sly-eval-async '(slynk:connection-info)
+  (lambda (result)
+    (message "Got: %S" result)))
+```
+
+**Synchronous (sly-eval):**
+```elisp
+(let ((result (sly-eval '(slynk:connection-info))))
+  (message "Got: %S" result))
+```
+
+Synchronous evaluation uses `accept-process-output` in a loop until the response arrives.
+
+### 3.4 Result Values
+
+RPC results are wrapped in status indicators:
+
+| Status | Meaning | Example |
+|--------|---------|---------|
+| `:ok` | Success | `(:ok 42)` |
+| `:abort` | Aborted (e.g., user interrupt) | `(:abort "User interrupt")` |
+| `:error` | Evaluation error | `(:error "Undefined function")` |
+
+---
+
+## 4. Connection Establishment
+
+### 4.1 Server Creation
+
+**Lisp side:**
+```lisp
+(slynk:create-server :port 4005
+                     :style :spawn
+                     :dont-close nil)
+```
+
+**Communication styles:**
+| Style | Description |
+|-------|-------------|
+| `:spawn` | Multithreaded (dedicated reader, control, worker threads) |
+| `:sigio` | Single-threaded with SIGIO signals |
+| `:fd-handler` | Single-threaded with file descriptor handlers |
+| `nil` | Polling-based single-threaded |
+
+### 4.2 Connection Sequence
+
+```
+┌─────────┐                              ┌──────────┐
+│  Emacs  │                              │  SLYNK   │
+└────┬────┘                              └────┬─────┘
+     │                                        │
+     │──── TCP Connect (port 4005) ──────────>│
+     │                                        │
+     │<─── [Optional: Secret Challenge] ──────│
+     │                                        │
+     │──── [Optional: Secret Response] ──────>│
+     │                                        │
+     │<─── Protocol handshake ────────────────│
+     │     (version info in S-expression)     │
+     │                                        │
+     │──── (:emacs-rex (slynk:connection-info)│
+     │                  "CL-USER" t 1) ───────>│
+     │                                        │
+     │<─── (:return (:ok (...)) 1) ───────────│
+     │                                        │
+     │     [Connection established]           │
+     │                                        │
+```
+
+### 4.3 Authentication
+
+Optional secret-based authentication via `~/.sly-secret` file.
+
+**Lisp side (slynk.lisp:1020-1027):**
+```lisp
+(defun authenticate-client (stream)
+  (let ((secret (sly-secret)))
+    (when secret
+      (set-stream-timeout stream 20)
+      (let ((first-val (read-packet stream)))
+        (unless (and (stringp first-val) (string= first-val secret))
+          (error "Incoming connection doesn't know the password."))))))
+```
+
+### 4.4 Connection Structure
+
+**Lisp side (slynk.lisp:206-243):**
+```lisp
+(defstruct (connection ...)
+  (socket           ...)  ; Raw socket
+  (socket-io        ...)  ; Stream for I/O
+  (channel-counter  0)    ; Counter for channel IDs
+  (channels         '())  ; Active channels
+  (listeners        '())  ; Event listeners
+  (inspectors       '())  ; Active inspectors
+  (indentation-cache ...)  ; Symbol indentation info
+  (communication-style nil))
+```
+
+---
+
+## 5. Channels
+
+Channels provide a mechanism for structured, stateful communication patterns that don't fit the simple RPC model.
+
+### 5.1 Channel Concept
+
+A channel is a named bidirectional communication endpoint. Each channel has:
+- Unique numeric ID
+- Associated thread
+- Set of message handlers
+
+### 5.2 Lisp Side (slynk.lisp:488-537)
+
+```lisp
+(defclass channel ()
+  ((id     :initform (incf (channel-counter))
+           :reader channel-id)
+   (thread :initarg :thread :initform (current-thread)
+           :reader channel-thread)
+   (name   :initarg :name :initform nil)))
+
+(defgeneric channel-send (channel selector args)
+  (:documentation "Send MSG to CHANNEL."))
+```
+
+### 5.3 Emacs Side (sly.el:2641-2700)
+
+```elisp
+(cl-defstruct (sly-channel (:conc-name sly-channel.)
+                           (:constructor sly-make-channel% ...))
+  operations name id plist)
+
+(defun sly-channel-send (channel message)
+  (sly-send `(:emacs-channel-send ,(sly-channel.id channel) ,message)))
+```
+
+### 5.4 Use Cases
+
+Channels are used by:
+- **MREPL** - Multiple REPLs over single connection
+- **Stickers** - Live value annotation streaming
+- **Trace Dialog** - Trace event streaming
+
+---
+
+## 6. Threading Model
+
+### 6.1 Multithreaded Mode (`:spawn`)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    SLYNK Server                         │
+│                                                         │
+│  ┌──────────────┐                                       │
+│  │ Reader Thread│──reads from socket──┐                 │
+│  └──────────────┘                     │                 │
+│                                       ▼                 │
+│                              ┌─────────────────┐        │
+│                              │ Control Thread  │        │
+│                              │  (dispatcher)   │        │
+│                              └────────┬────────┘        │
+│                                       │                 │
+│               ┌───────────────────────┼───────────────┐ │
+│               ▼                       ▼               ▼ │
+│        ┌────────────┐          ┌────────────┐  ┌───────┐│
+│        │ Worker #1  │          │ Worker #2  │  │  ...  ││
+│        │ (eval req) │          │ (eval req) │  │       ││
+│        └────────────┘          └────────────┘  └───────┘│
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Thread responsibilities:**
+
+| Thread | Role |
+|--------|------|
+| Reader | Reads raw bytes from socket, decodes messages, sends to control |
+| Control | Dispatches messages to appropriate workers/handlers |
+| Worker | Executes RPC requests, sends results back |
+
+### 6.2 Single-threaded Modes
+
+For Lisps without threading or when threading is disabled:
+- Messages queued in `sconn.event-queue`
+- Processed sequentially during `process-requests`
+- Interrupts handled via `events-enqueued` counter
+
+### 6.3 Thread Targeting
+
+```lisp
+;; slynk.lisp:1220-1231
+(defgeneric thread-for-evaluation (connection id)
+  (:method ((conn multithreaded-connection) (id (eql t)))
+    (spawn-worker-thread conn))   ; New thread
+  (:method ((conn multithreaded-connection) (id (eql :find-existing)))
+    (car (mconn.active-threads conn)))  ; Reuse existing
+  (:method (conn (id integer))
+    (find-thread id)))            ; Specific thread
+```
+
+---
+
+## 7. Error Handling
+
+### 7.1 Protocol-Level Errors
+
+**Reader errors (slynk-rpc.lisp:27-31):**
+```lisp
+(define-condition slynk-reader-error (reader-error)
+  ((packet :type string :initarg :packet
+           :reader slynk-reader-error.packet)
+   (cause :type reader-error :initarg :cause
+          :reader slynk-reader-error.cause)))
+```
+
+### 7.2 Connection Errors
+
+**Error handlers (slynk.lisp:318-341):**
+```lisp
+(defmacro with-slynk-error-handler ((connection) &body body)
+  "Close the connection on internal `slynk-error's.")
+
+(defmacro with-panic-handler ((connection) &body body)
+  "Close the connection on unhandled `serious-condition's.")
+```
+
+### 7.3 Evaluation Errors
+
+Evaluation errors enter the debugger rather than returning `:error`:
+1. Condition occurs during evaluation
+2. SLYNK sends `:debug` message
+3. Emacs displays SLY-DB buffer
+4. User selects restart or aborts
+5. SLYNK sends `:return` with `:ok` (restart) or `:abort`
+
+---
+
+## 8. Common RPC Functions
+
+These are the most commonly used SLYNK functions called via `:emacs-rex`:
+
+### 8.1 Connection & Info
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:connection-info` | Get server info (Lisp impl, version, features) |
+| `slynk:ping` | Check connection liveness |
+| `slynk:quit-lisp` | Terminate Lisp process |
+
+### 8.2 Evaluation
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:eval-and-grab-output` | Eval form, capture stdout |
+| `slynk:interactive-eval` | Eval with pretty result |
+| `slynk:interactive-eval-region` | Eval region string |
+| `slynk:re-evaluate-defvar` | Re-eval defvar form |
+| `slynk:pprint-eval` | Eval with pretty-printed result |
+
+### 8.3 Compilation
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:compile-string-for-emacs` | Compile string, return notes |
+| `slynk:compile-file-for-emacs` | Compile file, return notes |
+| `slynk:load-file` | Load compiled/source file |
+| `slynk:compile-notes-for-emacs` | Get compilation warnings |
+
+### 8.4 Completion
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:simple-completions` | Basic prefix completion |
+| `slynk:flex-completions` | Fuzzy/flex completion |
+| `slynk:completions-for-character` | Character name completion |
+| `slynk:completions-for-keyword` | Keyword completion |
+
+### 8.5 Documentation
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:documentation-symbol` | Get symbol docstring |
+| `slynk:describe-symbol` | Full symbol description |
+| `slynk:describe-function` | Function signature and docs |
+| `slynk:apropos-list-for-emacs` | Search symbols by name |
+
+### 8.6 Definition Finding
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:find-definitions-for-emacs` | Find definition locations |
+| `slynk:xref` | Cross-reference query |
+| `slynk:xrefs` | Multiple xref queries |
+
+### 8.7 Debugging
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:backtrace` | Get current backtrace |
+| `slynk:debugger-info-for-emacs` | Full debugger state |
+| `slynk:invoke-nth-restart-for-emacs` | Invoke restart by index |
+| `slynk:sldb-abort` | Abort to top level |
+| `slynk:sldb-continue` | Continue execution |
+| `slynk:frame-source-location` | Source location for frame |
+| `slynk:frame-locals-and-catch-tags` | Frame local variables |
+
+### 8.8 Inspection
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:init-inspector` | Start inspector on value |
+| `slynk:inspect-nth-part` | Inspect sub-object |
+| `slynk:inspector-call-nth-action` | Invoke inspector action |
+| `slynk:inspector-pop` | Go back in inspector |
+| `slynk:inspector-reinspect` | Refresh inspector view |
+
+### 8.9 Macroexpansion
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:slynk-macroexpand-1` | One-level macroexpand |
+| `slynk:slynk-macroexpand-all` | Full macroexpand |
+| `slynk:slynk-compiler-macroexpand-1` | Compiler macro expansion |
+
+### 8.10 Package Management
+
+| Function | Purpose |
+|----------|---------|
+| `slynk:list-all-package-names` | Get all package names |
+| `slynk:set-package` | Set current package |
+
+---
+
+## 9. Version Compatibility
+
+### 9.1 Protocol Version
+
+The protocol version is exchanged during connection establishment. Mismatched versions produce warnings but usually work.
+
+### 9.2 SLIME Compatibility
+
+SLY maintains partial backward compatibility with SLIME:
+- Core protocol messages are compatible
+- Some SWANK functions have SLYNK equivalents
+- The `slynk-retro` contrib provides translation layer
+
+### 9.3 Implementation-Specific Behavior
+
+Different Lisp implementations may:
+- Support different communication styles
+- Provide different levels of debugging info
+- Have varying threading capabilities
+
+---
+
+## 10. Security Considerations
+
+### 10.1 Network Exposure
+
+By default, SLYNK listens on localhost only. Exposing it to the network is dangerous as it allows arbitrary code execution.
+
+### 10.2 Secret File
+
+The `~/.sly-secret` file provides basic authentication but should not be relied upon for security in hostile environments.
+
+### 10.3 SSH Tunneling
+
+For remote development, SSH tunneling is recommended:
+```bash
+ssh -L 4005:localhost:4005 remote-host
+```
+
+---
+
+## Appendix A: Message Reference
+
+### A.1 Quick Reference Table
+
+| Direction | Message | Purpose |
+|-----------|---------|---------|
+| E→L | `:emacs-rex` | RPC request |
+| E→L | `:emacs-interrupt` | Interrupt evaluation |
+| E→L | `:emacs-return` | Return value to Lisp |
+| E→L | `:emacs-return-string` | Return string input |
+| E→L | `:emacs-pong` | Ping response |
+| E→L | `:emacs-channel-send` | Channel message |
+| L→E | `:return` | RPC response |
+| L→E | `:debug` | Enter debugger |
+| L→E | `:debug-activate` | Show debugger |
+| L→E | `:debug-return` | Exit debugger |
+| L→E | `:write-string` | Output text |
+| L→E | `:read-string` | Request input |
+| L→E | `:y-or-n-p` | Yes/no question |
+| L→E | `:eval` | Eval in Emacs |
+| L→E | `:channel-send` | Channel message |
+| L→E | `:ping` | Ping request |
+| L→E | `:new-package` | Package changed |
+| L→E | `:indentation-update` | Indentation info |
+
+### A.2 File References
+
+| File | Lines | Content |
+|------|-------|---------|
+| `slynk/slynk-rpc.lisp` | 1-212 | Wire protocol implementation |
+| `slynk/slynk.lisp` | 1273-1333 | Event dispatch |
+| `sly.el` | 1504-1740 | Network layer |
+| `sly.el` | 2248-2620 | Protocol dispatch |
+
+---
+
+*Document generated from SLY source code analysis. Last updated: 2025.*

--- a/doc/TESTING-CONTRIBS.md
+++ b/doc/TESTING-CONTRIBS.md
@@ -1,0 +1,449 @@
+# Testing Guide for SLY Contrib Authors
+
+This guide explains how to write tests for SLY contribs (extensions). It covers both unit tests and integration tests specific to contrib development.
+
+## Overview
+
+SLY contribs typically have both Elisp and Common Lisp components:
+- **Elisp side** (`contrib/sly-<name>.el`): Emacs UI and client logic
+- **Lisp side** (`slynk/contrib/slynk-<name>.lisp`): Server-side implementation
+
+Both sides need testing to ensure the contrib works correctly.
+
+## Test File Organization
+
+Contrib tests follow this structure:
+
+```
+sly/
+├── contrib/
+│   ├── sly-mrepl.el              # Contrib Elisp code
+│   └── test/
+│       ├── sly-mrepl-tests.el    # Integration tests for sly-mrepl
+│       └── sly-mrepl-unit-tests.el  # Unit tests (optional)
+└── slynk/contrib/
+    └── slynk-mrepl.lisp          # Contrib Lisp code
+```
+
+## Unit Tests vs Integration Tests
+
+### Unit Tests (Optional but Recommended)
+
+Unit tests verify pure Elisp functions without requiring a Lisp connection.
+
+**When to write unit tests:**
+- String parsing and formatting functions
+- Data structure manipulation
+- Pure utility functions
+- UI state management (without network calls)
+
+**Example unit test:**
+
+```elisp
+;;; sly-example-unit-tests.el --- Unit tests for sly-example -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'sly-example "contrib/sly-example")
+(require 'sly-unit-tests "lib/sly-unit-tests")
+(require 'sly-test-mocks "test/sly-test-mocks")
+
+(ert-deftest sly-example-unit--parse-output ()
+  "Test output parsing function."
+  (should (equal '(:result "success" :value 42)
+                 (sly-example--parse-result "success: 42"))))
+
+(ert-deftest sly-example-unit--with-mock-eval ()
+  "Test with mocked slynk call."
+  (sly-test-with-mock-eval
+      (((slynk-example:get-data) . (:data "mocked")))
+    (should (equal "mocked"
+                   (plist-get (sly-example-fetch-data) :data)))))
+
+(provide 'sly-example-unit-tests)
+```
+
+### Integration Tests (Required)
+
+Integration tests verify the complete Elisp-Lisp interaction with a live connection.
+
+**When to write integration tests:**
+- RPC calls to slynk functions (slyfuns)
+- REPL interactions
+- Complete feature workflows
+- Channel-based communication
+
+**Example integration test:**
+
+```elisp
+;;; sly-example-tests.el --- Integration tests for sly-example -*- lexical-binding: t; -*-
+
+(require 'sly-tests "lib/sly-tests")
+(require 'sly-example "contrib/sly-example")
+
+(def-sly-test example-basic-functionality ()
+  "Test basic example functionality."
+  (with-temp-buffer
+    (lisp-mode)
+    (sly-check "Can call example slyfun"
+      (let ((result (sly-eval '(slynk-example:compute 2 3))))
+        (equal 5 result)))))
+
+(def-sly-test example-async-operation ()
+  "Test async operation."
+  (with-temp-buffer
+    (lisp-mode)
+    (let ((result nil))
+      (sly-eval-async '(slynk-example:async-compute 10)
+        (lambda (r) (setq result r)))
+      (sly-sync-to-top-level 5)
+      (sly-check "Async result received"
+        (equal 20 result)))))
+
+(provide 'sly-example-tests)
+```
+
+## Running Contrib Tests
+
+### Running Your Contrib Tests
+
+```bash
+# Run integration tests for your contrib
+make check-example  # Replace 'example' with your contrib name
+
+# Run with specific Lisp
+LISP=ccl make check-example
+```
+
+### During Development
+
+```bash
+# Quick unit test run (if you have unit tests)
+emacs -Q --batch -L . -L contrib -L test \
+  --eval "(require 'ert)" \
+  --eval "(require 'sly-example-unit-tests)" \
+  --eval "(ert-run-tests-batch-and-exit)"
+
+# Integration test (requires running Lisp)
+emacs -Q -L . -L contrib \
+  --eval "(require 'sly)" \
+  --eval "(setq sly-contribs '(sly-example))" \
+  --eval "(setq inferior-lisp-program \"sbcl\")" \
+  -f sly
+# Then M-x sly-tests RET (tag contrib) RET
+```
+
+## Test Utilities for Contribs
+
+### From `lib/sly-tests.el`
+
+**`def-sly-test`**: Define integration tests
+
+```elisp
+(def-sly-test name (arguments)
+  "Docstring."
+  (test-body))
+```
+
+**`sly-check`**: Assert with descriptive error messages
+
+```elisp
+(sly-check "Operation succeeded"
+  (equal expected actual))
+```
+
+**`sly-sync-to-top-level`**: Wait for Lisp to return to top level
+
+```elisp
+(sly-sync-to-top-level 5)  ; Wait up to 5 seconds
+```
+
+**`sly-wait-condition`**: Wait for a condition to become true
+
+```elisp
+(sly-wait-condition "Buffer updated" 3.0
+  (equal (buffer-string) "Expected content"))
+```
+
+### From `lib/sly-unit-tests.el`
+
+**`sly-unit-with-temp-lisp-buffer`**: Create temporary Lisp buffer
+
+```elisp
+(sly-unit-with-temp-lisp-buffer "(defun foo () nil)"
+  (search-forward "foo")
+  (should (sly-at-function-p)))
+```
+
+**`sly-unit-with-stubbed-connection`**: Stub connection functions
+
+```elisp
+(sly-unit-with-stubbed-connection
+  (should (sly-connected-p)))
+```
+
+### From `test/sly-test-mocks.el`
+
+**`sly-test-with-mock-eval`**: Mock RPC evaluation
+
+```elisp
+(sly-test-with-mock-eval
+    (((slynk-example:foo "arg") . "result"))
+  (should (equal "result" (sly-eval '(slynk-example:foo "arg")))))
+```
+
+## Common Testing Patterns
+
+### Testing REPL Output
+
+```elisp
+(def-sly-test example-repl-output ()
+  "Test REPL output formatting."
+  (let ((output-buffer (sly-mrepl--find-buffer)))
+    (with-current-buffer output-buffer
+      (sly-eval '(slynk-example:print-message "Hello"))
+      (sly-sync-to-top-level 2)
+      (sly-check "Message appears in REPL"
+        (save-excursion
+          (goto-char (point-min))
+          (search-forward "Hello" nil t))))))
+```
+
+### Testing Interactive Commands
+
+```elisp
+(def-sly-test example-interactive-command ()
+  "Test interactive command."
+  (with-temp-buffer
+    (lisp-mode)
+    (insert "(defun test-fn () 42)")
+    (goto-char (point-min))
+    (search-forward "test-fn")
+    (call-interactively #'sly-example-describe-symbol)
+    (sly-sync-to-top-level 2)
+    (sly-check "Description buffer created"
+      (get-buffer "*sly-example-description*"))))
+```
+
+### Testing Async Operations
+
+```elisp
+(def-sly-test example-async-with-callback ()
+  "Test async operation with callback."
+  (let ((callback-called nil)
+        (callback-result nil))
+    (sly-eval-async '(slynk-example:long-running-op)
+      (lambda (result)
+        (setq callback-called t
+              callback-result result)))
+    (sly-wait-condition "Callback invoked" 5.0
+      callback-called)
+    (sly-check "Callback received correct result"
+      (equal "success" callback-result))))
+```
+
+### Testing Error Handling
+
+```elisp
+(def-sly-test example-error-handling ()
+  "Test that errors are handled gracefully."
+  (let ((error-signaled nil))
+    (condition-case err
+        (sly-eval '(slynk-example:will-error))
+      (error
+       (setq error-signaled t)))
+    (sly-check "Error was signaled"
+      error-signaled)))
+```
+
+### Testing Buffer Management
+
+```elisp
+(def-sly-test example-buffer-creation ()
+  "Test special buffer creation."
+  (let ((buf (sly-example-open-special-buffer)))
+    (unwind-protect
+        (progn
+          (sly-check "Buffer created"
+            (buffer-live-p buf))
+          (sly-check "Buffer has correct mode"
+            (with-current-buffer buf
+              (eq major-mode 'sly-example-mode))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+```
+
+## Testing Checklist for Contribs
+
+Before submitting your contrib, ensure:
+
+### Unit Tests (if applicable)
+- [ ] Pure functions have unit tests
+- [ ] String parsing/formatting is tested
+- [ ] Mock tests verify RPC interaction patterns
+- [ ] All unit tests pass: `make check-unit` (if added to suite)
+
+### Integration Tests (required)
+- [ ] Main feature workflows are tested
+- [ ] Interactive commands are tested
+- [ ] REPL interactions are tested
+- [ ] Error cases are tested
+- [ ] Async operations are tested
+- [ ] Tests pass on SBCL: `make check-<contrib>`
+- [ ] Tests pass on CCL: `LISP=ccl make check-<contrib>`
+
+### Test Quality
+- [ ] Test names are descriptive
+- [ ] Tests are independent (can run in any order)
+- [ ] Tests clean up resources (buffers, overlays, timers)
+- [ ] No hardcoded timeouts (use `sly-wait-condition`)
+- [ ] Tests document expected behavior
+
+### Documentation
+- [ ] CONTRIBUTING.md updated with test instructions
+- [ ] Contrib README mentions how to run tests
+- [ ] Complex test scenarios are commented
+
+## Adding Your Contrib to CI
+
+To add your contrib tests to GitHub Actions CI:
+
+1. **Add Makefile target** in main `Makefile`:
+
+```makefile
+check-example: CONTRIB_NAME=sly-example
+check-example: SELECTOR=(tag contrib)
+check-example: compile contrib/sly-example.elc contrib/test/sly-example-tests.elc
+	$(EMACS) -Q --batch $(LOAD_PATH) -L test			\
+		--eval "(require (quote sly))"				\
+		--eval "(setq sly-contribs (quote (sly-example)))"	\
+		--eval "(require (intern (format \"%s-tests\" (quote sly-example))))" \
+		--eval "(setq inferior-lisp-program \"$(LISP)\")"	\
+		--eval '(sly-batch-test (quote $(SELECTOR)))'
+```
+
+2. **Tests will run automatically** in the CI matrix with the `check-fancy` target if your contrib is part of `sly-fancy`.
+
+## Debugging Test Failures
+
+### Run Tests Interactively
+
+```bash
+emacs -Q -L . -L contrib \
+  --eval "(require 'sly)" \
+  --eval "(setq sly-contribs '(sly-example))" \
+  --eval "(setq inferior-lisp-program \"sbcl\")" \
+  -f sly
+```
+
+Then:
+1. `M-x load-library RET contrib/test/sly-example-tests RET`
+2. `M-x ert RET t RET` to run all tests interactively
+3. Click on failed test to see details
+
+### Enable SLY Event Tracing
+
+```elisp
+(setq sly-log-events t)
+;; View events in *sly-events* buffer
+```
+
+### Add Debug Output
+
+```elisp
+(def-sly-test example-debug ()
+  "Test with debug output."
+  (let ((sly-inhibit-pipelining nil))
+    (message "About to call slyfun...")
+    (let ((result (sly-eval '(slynk-example:foo))))
+      (message "Result: %S" result)
+      (sly-check "Got result" result))))
+```
+
+## Common Pitfalls
+
+### ❌ Hardcoded Timeouts
+
+```elisp
+;; BAD
+(sleep-for 2)
+(sly-check "Operation completed" (buffer-updated-p))
+```
+
+```elisp
+;; GOOD
+(sly-wait-condition "Buffer updated" 5.0
+  (buffer-updated-p))
+```
+
+### ❌ Not Cleaning Up Resources
+
+```elisp
+;; BAD
+(def-sly-test example-leak ()
+  (let ((buf (generate-new-buffer "*test*")))
+    (test-something buf)))
+    ;; Buffer never killed!
+```
+
+```elisp
+;; GOOD
+(def-sly-test example-cleanup ()
+  (let ((buf (generate-new-buffer "*test*")))
+    (unwind-protect
+        (test-something buf)
+      (kill-buffer buf))))
+```
+
+### ❌ Tests Depend on Each Other
+
+```elisp
+;; BAD - Tests share state
+(defvar example-test-state nil)
+
+(def-sly-test example-setup ()
+  (setq example-test-state "initialized"))
+
+(def-sly-test example-use-state ()
+  (sly-check "State exists" example-test-state))  ; Fails if run alone!
+```
+
+```elisp
+;; GOOD - Each test is independent
+(def-sly-test example-independent ()
+  (let ((state "initialized"))
+    (sly-check "State exists" state)))
+```
+
+### ❌ Assuming Specific Emacs Configuration
+
+```elisp
+;; BAD - Assumes user config
+(def-sly-test example-assumes-config ()
+  (sly-check "Feature enabled" some-user-option))
+```
+
+```elisp
+;; GOOD - Explicit setup
+(def-sly-test example-explicit ()
+  (let ((some-user-option t))
+    (sly-check "Feature works when enabled" (feature-p))))
+```
+
+## Additional Resources
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md#testing) - Main testing guide
+- [lib/sly-tests.el](../lib/sly-tests.el) - Integration test framework source
+- [lib/sly-unit-tests.el](../lib/sly-unit-tests.el) - Unit test utilities source
+- [test/sly-test-mocks.el](../test/sly-test-mocks.el) - Mocking framework source
+- Existing contrib tests: `contrib/test/sly-*-tests.el` for examples
+
+## Getting Help
+
+If you need help writing tests for your contrib:
+
+1. Look at existing contrib tests for patterns
+2. Check [GitHub Discussions](https://github.com/joaotavora/sly/discussions)
+3. Ask in #lisp on Libera.Chat IRC
+4. Open an issue labeled "question"
+
+Happy testing! 🧪

--- a/doc/TESTING-FLAKY-TESTS.md
+++ b/doc/TESTING-FLAKY-TESTS.md
@@ -1,0 +1,461 @@
+# Flaky Tests: Patterns and Solutions
+
+This document describes common patterns that lead to flaky (non-deterministic) tests in SLY and how to fix them. A flaky test is one that sometimes passes and sometimes fails without any code changes.
+
+## Table of Contents
+
+- [Race Conditions](#race-conditions)
+- [Timing Issues](#timing-issues)
+- [State Leakage](#state-leakage)
+- [Environment Dependencies](#environment-dependencies)
+- [Resource Management](#resource-management)
+- [Async Operations](#async-operations)
+- [Prevention Checklist](#prevention-checklist)
+
+## Race Conditions
+
+### Problem: Tests Depend on Uncontrolled Timing
+
+**Symptoms:**
+- Test passes locally but fails in CI
+- Test fails randomly, especially under load
+- "Expected X but got Y" errors where Y is an intermediate state
+
+**Example of Flaky Test:**
+
+```elisp
+(def-sly-test flaky-completion ()
+  "Flaky test that races with async completion."
+  (with-temp-buffer
+    (insert "def")
+    (sly-complete-symbol)  ; Async operation
+    (sleep-for 0.1)  ; ❌ Fixed delay - may be too short or too long
+    (sly-check "Completion appeared"
+      (looking-at "defun"))))
+```
+
+**Solution: Use Condition-Based Waiting**
+
+```elisp
+(def-sly-test robust-completion ()
+  "Robust test using condition-based waiting."
+  (with-temp-buffer
+    (insert "def")
+    (sly-complete-symbol)
+    ;; ✅ Wait for actual condition, not fixed time
+    (sly-wait-condition "Completion appeared" 3.0
+      (looking-at "defun"))
+    (sly-check "Completion is correct"
+      (equal "defun" (buffer-substring (point-min) (point))))))
+```
+
+**Key Points:**
+- Never use `sleep-for` to wait for async operations
+- Always use `sly-wait-condition` with a reasonable timeout
+- Test for actual state changes, not elapsed time
+
+## Timing Issues
+
+### Problem: Hardcoded Timeouts
+
+**Symptoms:**
+- Tests fail on slower machines or in CI
+- Tests pass when run individually but fail in batch
+- Timeout values seem arbitrary (0.1s, 0.5s, etc.)
+
+**Example of Flaky Test:**
+
+```elisp
+(def-sly-test flaky-repl-output ()
+  "Flaky test with hardcoded timeout."
+  (sly-eval '(cl:sleep 0.05))
+  (sleep-for 0.1)  ; ❌ Assumes operation completes in 0.1s
+  (sly-check "Output received"
+    (buffer-contains-p "NIL")))
+```
+
+**Solution: Synchronize to Known State**
+
+```elisp
+(def-sly-test robust-repl-output ()
+  "Robust test using synchronization."
+  (sly-eval '(cl:sleep 0.05))
+  ;; ✅ Wait for Lisp to return to top level
+  (sly-sync-to-top-level 5)
+  (sly-check "Output received"
+    (buffer-contains-p "NIL")))
+```
+
+**Alternative: Event-Based Waiting**
+
+```elisp
+(def-sly-test robust-repl-output-v2 ()
+  "Robust test using event tracking."
+  (let ((output-received nil))
+    (sly-eval-async '(cl:sleep 0.05)
+      (lambda (result)
+        (setq output-received t)))
+    ;; ✅ Wait for actual callback invocation
+    (sly-wait-condition "Output received" 5.0
+      output-received)
+    (sly-check "Result is correct"
+      output-received)))
+```
+
+**Key Points:**
+- Use `sly-sync-to-top-level` after synchronous evaluations
+- Use `sly-wait-condition` with callbacks for async operations
+- Timeout values should be generous (3-10 seconds for complex operations)
+
+## State Leakage
+
+### Problem: Tests Affect Each Other
+
+**Symptoms:**
+- Tests pass when run individually but fail in batch
+- Test order matters (Test A fails if Test B runs first)
+- Mysterious failures with "expected nil but got X"
+
+**Example of Flaky Test:**
+
+```elisp
+;; ❌ Global state shared between tests
+(defvar test-shared-buffer nil)
+
+(def-sly-test flaky-setup ()
+  (setq test-shared-buffer (generate-new-buffer "*test*"))
+  (with-current-buffer test-shared-buffer
+    (insert "data")))
+
+(def-sly-test flaky-use ()
+  ;; Fails if flaky-setup didn't run first!
+  (sly-check "Buffer exists"
+    (buffer-live-p test-shared-buffer)))
+```
+
+**Solution: Isolate Test State**
+
+```elisp
+;; ✅ Each test manages its own state
+(def-sly-test robust-test ()
+  (let ((test-buffer (generate-new-buffer "*test*")))
+    (unwind-protect
+        (with-current-buffer test-buffer
+          (insert "data")
+          (sly-check "Buffer has data"
+            (= 4 (buffer-size))))
+      ;; Always clean up
+      (when (buffer-live-p test-buffer)
+        (kill-buffer test-buffer)))))
+```
+
+**Key Points:**
+- Never use global variables to share state between tests
+- Always use `unwind-protect` to ensure cleanup
+- Each test should be completely independent
+
+## Environment Dependencies
+
+### Problem: Tests Assume Specific Configuration
+
+**Symptoms:**
+- Tests fail for some users but not others
+- Tests fail with different Emacs versions
+- Tests fail with different Common Lisp implementations
+
+**Example of Flaky Test:**
+
+```elisp
+(def-sly-test flaky-user-config ()
+  "Flaky test assuming user configuration."
+  ;; ❌ Assumes user has this package installed
+  (require 'company)
+  (sly-check "Company completion works"
+    (sly-company-active-p)))
+```
+
+**Solution: Explicit Test Setup**
+
+```elisp
+(def-sly-test robust-optional-feature ()
+  "Robust test with optional dependency."
+  ;; ✅ Gracefully handle optional features
+  (if (require 'company nil t)
+      (sly-check "Company completion works"
+        (sly-company-active-p))
+    (message "Skipping company test - not installed")))
+```
+
+**Better Solution: Feature Flags**
+
+```elisp
+(def-sly-test robust-optional-feature-v2 ()
+  "Test with proper feature detection."
+  :tags '(requires-company)  ; Tag for selective running
+  (unless (featurep 'company)
+    (ert-skip "Company not available"))
+  (sly-check "Company completion works"
+    (sly-company-active-p)))
+```
+
+**Key Points:**
+- Don't assume packages beyond SLY's dependencies are available
+- Use `ert-skip` for tests requiring optional features
+- Tag tests that have special requirements
+
+## Resource Management
+
+### Problem: Tests Leak Resources
+
+**Symptoms:**
+- Memory usage grows during test runs
+- "Too many open files" errors
+- Buffers or processes left behind after tests
+
+**Example of Flaky Test:**
+
+```elisp
+(def-sly-test flaky-resource-leak ()
+  "Flaky test that leaks buffers."
+  (dotimes (i 100)
+    (let ((buf (generate-new-buffer (format "*test-%d*" i))))
+      ;; ❌ Buffers never killed
+      (with-current-buffer buf
+        (insert "data")
+        (sly-check "Buffer created" t)))))
+```
+
+**Solution: Proper Resource Cleanup**
+
+```elisp
+(def-sly-test robust-resource-management ()
+  "Robust test with cleanup."
+  (dotimes (i 100)
+    (let ((buf (generate-new-buffer (format "*test-%d*" i))))
+      (unwind-protect
+          (with-current-buffer buf
+            (insert "data")
+            (sly-check "Buffer created" t))
+        ;; ✅ Always clean up
+        (when (buffer-live-p buf)
+          (kill-buffer buf))))))
+```
+
+**For Complex Resources:**
+
+```elisp
+(defmacro with-test-resources (&rest body)
+  "Execute BODY with automatic resource cleanup."
+  (declare (indent 0))
+  (let ((buffers (cl-gensym "buffers"))
+        (overlays (cl-gensym "overlays")))
+    `(let ((,buffers nil)
+           (,overlays nil))
+       (cl-flet ((track-buffer (buf)
+                   (push buf ,buffers)
+                   buf)
+                 (track-overlay (ov)
+                   (push ov ,overlays)
+                   ov))
+         (unwind-protect
+             (progn ,@body)
+           ;; Cleanup
+           (mapc #'kill-buffer
+                 (cl-remove-if-not #'buffer-live-p ,buffers))
+           (mapc #'delete-overlay ,overlays))))))
+```
+
+**Key Points:**
+- Always use `unwind-protect` for cleanup
+- Track all created resources (buffers, overlays, timers, processes)
+- Clean up even when tests fail
+
+## Async Operations
+
+### Problem: Callbacks Not Invoked Yet
+
+**Symptoms:**
+- Tests fail with "callback not called"
+- Tests pass sometimes (when machine is fast)
+- Tests fail under debugger (timing changes)
+
+**Example of Flaky Test:**
+
+```elisp
+(def-sly-test flaky-async ()
+  "Flaky async test."
+  (let ((result nil))
+    (sly-eval-async '(slynk:connection-info)
+      (lambda (info)
+        (setq result info)))
+    ;; ❌ Result might not be set yet
+    (sly-check "Got result"
+      result)))
+```
+
+**Solution: Wait for Callback**
+
+```elisp
+(def-sly-test robust-async ()
+  "Robust async test."
+  (let ((result nil)
+        (callback-called nil))
+    (sly-eval-async '(slynk:connection-info)
+      (lambda (info)
+        (setq result info
+              callback-called t)))
+    ;; ✅ Wait for callback
+    (sly-wait-condition "Callback invoked" 5.0
+      callback-called)
+    (sly-check "Got result"
+      result)
+    (sly-check "Result has expected structure"
+      (plist-get result :pid))))
+```
+
+**Key Points:**
+- Never check async results immediately
+- Use flags to track callback invocation
+- Use `sly-wait-condition` to wait for flags
+
+## Prevention Checklist
+
+Before merging a test, verify:
+
+### Timing
+- [ ] No `sleep-for` or fixed delays
+- [ ] Uses `sly-wait-condition` for async operations
+- [ ] Uses `sly-sync-to-top-level` after eval
+- [ ] Timeout values are generous (≥3 seconds)
+
+### Independence
+- [ ] Test doesn't modify global state
+- [ ] Test doesn't depend on other tests
+- [ ] Test cleans up all resources in `unwind-protect`
+- [ ] Test can run in any order
+
+### Determinism
+- [ ] Test doesn't use random values without seeding
+- [ ] Test doesn't depend on current time/date
+- [ ] Test doesn't depend on file system state
+- [ ] Test doesn't depend on network availability
+
+### Resource Management
+- [ ] All buffers are killed
+- [ ] All overlays are deleted
+- [ ] All timers are canceled
+- [ ] All processes are killed
+- [ ] All temp files are deleted
+
+### Environment
+- [ ] Test doesn't assume specific Emacs configuration
+- [ ] Test doesn't assume specific OS
+- [ ] Test works with both SBCL and CCL
+- [ ] Test doesn't require optional packages without checking
+
+## Debugging Flaky Tests
+
+### Technique 1: Run in Loop
+
+```bash
+# Run test 100 times to expose flakiness
+for i in {1..100}; do
+  echo "Run $i"
+  make check-unit || break
+done
+```
+
+### Technique 2: Add Instrumentation
+
+```elisp
+(def-sly-test debug-flaky ()
+  "Instrumented test."
+  (let ((start (current-time)))
+    (sly-eval-async '(slynk:connection-info)
+      (lambda (info)
+        (message "Callback after %.3fs"
+                 (float-time (time-since start)))))
+    (sly-sync-to-top-level 10)
+    ;; Check timing in *Messages* buffer
+    ))
+```
+
+### Technique 3: Enable Event Logging
+
+```elisp
+(setq sly-log-events t)
+;; View *sly-events* buffer to see all RPC traffic
+```
+
+### Technique 4: Bisect Test Suite
+
+```bash
+# Find which test causes state corruption
+# Run tests in different orders
+make check-unit SELECTOR='(or (tag test-group-a) (tag test-group-b))'
+```
+
+## Real-World Examples
+
+### Example 1: REPL Output Timing
+
+**Before (Flaky):**
+```elisp
+(def-sly-test flaky-repl-output-example ()
+  (sly-eval '(+ 1 2))
+  (sleep-for 0.2)
+  (sly-check "Output appeared" (looking-at "3")))
+```
+
+**After (Robust):**
+```elisp
+(def-sly-test robust-repl-output-example ()
+  (sly-eval '(+ 1 2))
+  (sly-sync-to-top-level 3)
+  (sly-check "Output appeared"
+    (save-excursion
+      (goto-char (point-min))
+      (re-search-forward "^3$" nil t))))
+```
+
+### Example 2: Buffer Creation Race
+
+**Before (Flaky):**
+```elisp
+(def-sly-test flaky-inspector-example ()
+  (sly-inspect '(list 1 2 3))
+  (sleep-for 0.5)
+  (sly-check "Inspector buffer exists"
+    (get-buffer "*sly-inspector*")))
+```
+
+**After (Robust):**
+```elisp
+(def-sly-test robust-inspector-example ()
+  (sly-inspect '(list 1 2 3))
+  (sly-sync-to-top-level 3)
+  (sly-wait-condition "Inspector buffer created" 3.0
+    (get-buffer "*sly-inspector*"))
+  (sly-check "Inspector shows list"
+    (with-current-buffer "*sly-inspector*"
+      (buffer-contains-p "LIST"))))
+```
+
+## Summary
+
+**Golden Rules for Non-Flaky Tests:**
+
+1. **Never use fixed delays** - Always wait for actual conditions
+2. **Always clean up** - Use `unwind-protect` for all resources
+3. **Tests must be independent** - No shared global state
+4. **Be patient** - Use generous timeouts (seconds, not milliseconds)
+5. **Test what matters** - Wait for the actual state change, not time elapsed
+
+Following these patterns will make your tests reliable across all environments and CI systems.
+
+## Additional Resources
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md#testing) - Main testing guide
+- [TESTING-CONTRIBS.md](TESTING-CONTRIBS.md) - Contrib testing guide
+- [lib/sly-tests.el](../lib/sly-tests.el) - Test framework with `sly-wait-condition`
+- [GitHub Issues](https://github.com/joaotavora/sly/issues?q=is%3Aissue+flaky+test) - Historical flaky test issues

--- a/doc/TESTING-UNIT-TESTS.md
+++ b/doc/TESTING-UNIT-TESTS.md
@@ -1,0 +1,701 @@
+# SLY Unit Testing Guide
+
+## What This Is
+
+SLY has a comprehensive unit test suite that tests Emacs Lisp functionality **without requiring a live Lisp connection**. This guide explains how the tests work, how to write new tests, and how to extend the test framework.
+
+## Why Unit Tests Matter
+
+SLY is a client-server system where Emacs (client) talks to Common Lisp (server). But much of SLY's code is pure Elisp—buffer manipulation, parsing, UI logic—that works independently. Unit tests verify this code works correctly without the overhead of starting a Lisp process.
+
+**Benefits:**
+- Fast feedback (tests run in seconds, not minutes)
+- Isolated testing (no external dependencies)
+- Safe refactoring (you'll know immediately if you break something)
+- Clear specifications (tests document how code should behave)
+
+## Your First Unit Test
+
+Here's a complete working test you can run right now:
+
+```elisp
+;; File: test/sly-example-unit-tests.el
+;;; -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'sly-unit-tests "lib/sly-unit-tests")
+
+(ert-deftest sly-example-unit--string-manipulation ()
+  "Test that string-upcase works."
+  (should (equal "HELLO" (string-upcase "hello"))))
+
+(provide 'sly-example-unit-tests)
+```
+
+Run it:
+```bash
+make check-unit
+```
+
+Expected output:
+```
+Running 131 tests...
+   passed  131/131  sly-...-unit--...
+```
+
+You now have a working test. See [Common Test Patterns](#common-test-patterns) to learn what you can test.
+
+## How Tests Are Organized
+
+All unit tests follow this structure:
+
+```
+lib/sly-unit-tests.el          # Test framework and utilities
+test/sly-test-mocks.el         # Mock objects for testing without Lisp
+test/sly-test-coverage.el      # Coverage configuration
+test/sly-*-unit-tests.el       # 7 test modules covering SLY features
+```
+
+### Test Modules
+
+Each module tests a specific SLY library:
+
+| Module | Tests | Coverage |
+|--------|-------|----------|
+| `sly-buttons-unit-tests.el` | 17 | Button system (overlays, types, keymaps) |
+| `sly-common-unit-tests.el` | 21 | Buffer manipulation and refresh utilities |
+| `sly-completion-unit-tests.el` | 18 | Completion system and annotation |
+| `sly-hyperspec-unit-tests.el` | 18 | HyperSpec symbol lookup and deduplication |
+| `sly-messages-unit-tests.el` | 24 | Message formatting, prompts, and feedback |
+| `sly-parse-unit-tests.el` | 33 | Parsing, syntax detection, form location |
+| `sly-test-mocks.el` | — | Mock implementations for testing RPC calls |
+
+**Total: 131 unit tests across 7 modules**
+
+## Common Test Patterns
+
+### Pattern 1: Testing Pure Functions
+
+```elisp
+(ert-deftest sly-example-unit--string-trim ()
+  "Test `string-trim' removes whitespace."
+  (should (equal "hello" (string-trim "  hello  "))))
+```
+
+Use `should` to assert the expected value is true.
+
+### Pattern 2: Testing with Temp Buffers
+
+Many SLY functions work with Emacs buffers. Use `sly-unit-with-temp-lisp-buffer` to create a test buffer:
+
+```elisp
+(ert-deftest sly-example-unit--find-symbol-at-point ()
+  "Test that symbol-at-point works in Lisp code."
+  (sly-unit-with-temp-lisp-buffer "foo bar baz"
+    (goto-char 5)  ; Position at "bar"
+    (should (equal "bar" (symbol-at-point)))))
+```
+
+The macro creates a temporary Lisp-mode buffer with your content, then executes the test code. The buffer is automatically cleaned up afterward.
+
+### Pattern 3: Testing with Point Markers
+
+Use the `|` character to mark where point should be:
+
+```elisp
+(ert-deftest sly-example-unit--complete-symbol ()
+  "Test completion at cursor position."
+  (sly-unit-with-temp-lisp-buffer-point "sym|bol"
+    ;; Point is now between "sym" and "bol"
+    (should (equal 4 (point)))))
+```
+
+The `|` is automatically removed and point is placed there.
+
+### Pattern 4: Testing with Mocked Functions
+
+When your code calls other functions, mock them to control behavior:
+
+```elisp
+(ert-deftest sly-example-unit--with-mocked-function ()
+  "Test that our function calls helper correctly."
+  (sly-unit-with-mock
+      ((helper-function (lambda () "mocked result")))
+    (should (equal "mocked result" (helper-function)))))
+```
+
+This temporarily replaces `helper-function` with the lambda for the duration of the test.
+
+### Pattern 5: Testing with a Stubbed Connection
+
+Some SLY functions check if a connection exists. Stub it:
+
+```elisp
+(ert-deftest sly-example-unit--with-stubbed-connection ()
+  "Test code that requires a connection."
+  (sly-unit-with-stubbed-connection
+    ;; Inside this block, (sly-connected-p) returns t
+    (should (sly-connected-p))))
+```
+
+This mocks `sly-connected-p`, `sly-current-connection`, `sly-current-package`, and `sly-buffer-package`.
+
+### Pattern 6: Testing RPC Calls with Mock Responses
+
+When your code evaluates Lisp, mock the responses:
+
+```elisp
+(ert-deftest sly-example-unit--eval-with-mock-response ()
+  "Test code that calls sly-eval."
+  (sly-test-with-mock-eval
+      (((slynk:my-function "arg") . "result from Lisp"))
+    ;; Inside this block, (sly-eval '(slynk:my-function "arg"))
+    ;; returns "result from Lisp"
+    (let ((result (sly-eval '(slynk:my-function "arg"))))
+      (should (equal "result from Lisp" result)))))
+```
+
+Map each Lisp call to its response. Responses can be values or functions that compute a result.
+
+### Pattern 7: Testing Error Conditions
+
+Use `should-error` to verify errors are raised when expected:
+
+```elisp
+(ert-deftest sly-example-unit--error-on-bad-input ()
+  "Test that function errors on invalid input."
+  (should-error (my-function-that-validates nil)))
+```
+
+Or check the error type:
+
+```elisp
+(ert-deftest sly-example-unit--type-error ()
+  "Test that function raises type-error."
+  (should-error
+    (my-function-that-validates 42)
+    :type 'type-error))
+```
+
+### Pattern 8: Testing Overlays and Buttons
+
+Create test overlays with the overlay test utilities:
+
+```elisp
+(ert-deftest sly-example-unit--overlay-properties ()
+  "Test that overlay has correct properties."
+  (sly-unit-with-overlays
+      ((ov 1 10 'my-prop "value"))
+    (should (equal "value" (overlay-get ov 'my-prop)))))
+```
+
+The macro creates overlays, executes your code, then deletes them.
+
+## Testing Framework Reference
+
+### Macros for Test Setup
+
+These macros create test environments:
+
+#### `sly-unit-with-temp-lisp-buffer`
+Create a temporary Lisp-mode buffer.
+
+```elisp
+(sly-unit-with-temp-lisp-buffer "(defun foo () 42)"
+  (goto-char 10)
+  (test-code-here))
+```
+
+#### `sly-unit-with-temp-lisp-buffer-point`
+Create a temp buffer where `|` marks the point position.
+
+```elisp
+(sly-unit-with-temp-lisp-buffer-point "(defun |foo () 42)"
+  ;; Point is between "(" and "foo"
+  (test-code-here))
+```
+
+#### `sly-unit-with-mock`
+Temporarily replace functions.
+
+```elisp
+(sly-unit-with-mock
+    ((my-function (lambda (x) (* x 2)))
+     (another-function (lambda () "test")))
+  ;; my-function and another-function are replaced
+  (test-code-here))
+```
+
+#### `sly-unit-with-stubbed-connection`
+Mock connection-related functions.
+
+```elisp
+(sly-unit-with-stubbed-connection
+  ;; (sly-connected-p) => t
+  ;; (sly-current-connection) => 'mock-connection
+  ;; (sly-current-package) => "CL-USER"
+  (test-code-here))
+```
+
+#### `sly-test-with-mock-eval`
+Mock `sly-eval` and `sly-eval-async` with predefined responses.
+
+```elisp
+(sly-test-with-mock-eval
+    (((slynk:my-function "a") . "result")
+     ((slynk:other-function) . (1 2 3)))
+  ;; sly-eval now returns mocked values
+  (test-code-here))
+```
+
+### Assertion Helpers
+
+#### `should`
+Assert that a value is true.
+
+```elisp
+(should (= 5 (+ 2 3)))
+(should (member 'foo '(foo bar)))
+```
+
+#### `should-not`
+Assert that a value is false.
+
+```elisp
+(should-not (= 5 (+ 2 2)))
+```
+
+#### `should-error`
+Assert that code raises an error.
+
+```elisp
+(should-error (error "oops"))
+(should-error (/ 1 0) :type 'arith-error)
+```
+
+#### `sly-unit-should-match`
+Assert that a string matches a regex.
+
+```elisp
+(sly-unit-should-match "^foo" "foobar")
+```
+
+#### `sly-unit-should-equal-normalized`
+Assert that strings are equal after normalizing whitespace.
+
+```elisp
+(sly-unit-should-equal-normalized
+  "hello world"
+  "hello   world")  ; Extra spaces are ignored
+```
+
+### Mock Object Utilities
+
+#### `sly-test-with-mock-connection`
+Set up a mock connection without eval responses.
+
+```elisp
+(sly-test-with-mock-connection
+  ;; Connection exists but no eval behavior
+  (should (sly-connected-p)))
+```
+
+#### `sly-test-mock-assert-called`
+Assert that a mocked function was called.
+
+```elisp
+(sly-test-with-mock-eval (((slynk:foo) . t))
+  (sly-eval '(slynk:foo))
+  (sly-test-mock-assert-called 'sly-eval))
+```
+
+#### `sly-test-mock-assert-called-with`
+Assert that a mocked function was called with specific arguments.
+
+```elisp
+(sly-test-with-mock-eval (((slynk:foo "arg") . t))
+  (sly-eval '(slynk:foo "arg"))
+  (sly-test-mock-assert-called-with 'sly-eval
+    '((slynk:foo "arg"))))
+```
+
+## Adding Tests to Your Module
+
+### Step 1: Choose Your Test Module
+
+Decide which test file your test belongs in:
+
+- **Buffer/UI code?** → `sly-common-unit-tests.el`
+- **Button system?** → `sly-buttons-unit-tests.el`
+- **Completion logic?** → `sly-completion-unit-tests.el`
+- **Parsing/syntax?** → `sly-parse-unit-tests.el`
+- **Message formatting?** → `sly-messages-unit-tests.el`
+- **HyperSpec lookup?** → `sly-hyperspec-unit-tests.el`
+- **New feature?** → Create `sly-myfeature-unit-tests.el`
+
+### Step 2: Organize Your Tests
+
+Group related tests under a section header:
+
+```elisp
+;;;; Tests for my-new-function
+;;;;
+
+(ert-deftest sly-example-unit--my-new-function-basic ()
+  "Test basic behavior."
+  (should ...))
+
+(ert-deftest sly-example-unit--my-new-function-edge-case ()
+  "Test edge case."
+  (should ...))
+```
+
+### Step 3: Name Your Test
+
+Follow the naming convention:
+
+```
+sly-[module]-unit--[function-name]-[scenario]
+```
+
+Examples:
+- `sly-buttons-unit--level-default` (module: buttons, function: level, scenario: default value)
+- `sly-completion-unit--string-detection-in-comment` (module: completion, function: string-detection, scenario: in-comment)
+- `sly-parse-unit--form-at-point-nested-parens` (module: parse, function: form-at-point, scenario: nested-parens)
+
+### Step 4: Write a Clear Docstring
+
+The docstring is the first thing maintainers read. Make it clear:
+
+```elisp
+;; Good - describes what's being tested and the scenario
+(ert-deftest sly-buttons-unit--level-returns-zero-by-default ()
+  "Test that `sly-button--level' returns 0 when not set."
+  ...)
+
+;; Bad - too vague
+(ert-deftest sly-buttons-unit--test-level ()
+  "Test level."
+  ...)
+```
+
+### Step 5: Write Your Test Body
+
+Keep it focused and readable:
+
+```elisp
+(ert-deftest sly-example-unit--my-function-basic ()
+  "Test `my-function' returns expected value."
+  ;; Setup: create test data
+  (let ((input '(1 2 3)))
+    ;; Action: call the function
+    (let ((result (my-function input)))
+      ;; Assertion: verify the result
+      (should (equal '(2 3 4) result)))))
+```
+
+## Module Details
+
+### sly-buttons-unit-tests.el
+
+Tests button system functionality:
+
+- **Button levels**: How deeply nested a button is (for visual styling)
+- **Button types**: Inheritance hierarchy (sly-action, sly-part)
+- **Button creation**: Making clickable buttons with properties
+- **Button finding**: Querying buttons at positions and by type
+- **Keymaps**: Button navigation and interaction bindings
+
+**Key utilities tested:**
+- `sly-button--level`: Get/set button nesting level
+- `sly-button--overlays-in`: Find buttons in a region
+- `sly-make-action-button`: Create clickable buttons
+- `sly-button-at`: Find button at point
+
+**When to add tests:** When modifying button behavior, button type hierarchies, or button keymaps.
+
+### sly-common-unit-tests.el
+
+Tests common buffer manipulation utilities:
+
+- **Buffer refresh**: Managing point and regions during buffer modifications
+- **Overlay management**: Creating and manipulating overlays
+- **Narrowing**: Working with narrowed regions
+- **Point recovery**: Keeping point in correct position during edits
+
+**Key utilities tested:**
+- `sly--call-refreshing`: Execute code while preserving buffer state
+- `sly-refreshing`: Macro version for cleaner code
+- Buffer content manipulation with overlays
+
+**When to add tests:** When modifying how SLY updates buffers (REPLs, inspector, etc.).
+
+### sly-completion-unit-tests.el
+
+Tests completion system:
+
+- **Annotation display**: Showing completion metadata
+- **String/comment detection**: Suppressing completion in wrong contexts
+- **Caching**: Completion result caching
+- **Wrapper behavior**: How completion wraps Lisp responses
+
+**Key utilities tested:**
+- `sly-completion-at-point`: Main completion function
+- Annotation formatting
+- Context detection (string vs code)
+
+**When to add tests:** When modifying completion behavior or adding new metadata.
+
+### sly-hyperspec-unit-tests.el
+
+Tests HyperSpec symbol lookup:
+
+- **Package prefix stripping**: Removing CL::, COMMON-LISP:: prefixes
+- **Symbol deduplication**: Removing duplicate symbols
+- **Case sensitivity**: Handling symbol case correctly
+- **Special characters**: Symbols with unusual names
+
+**Key utilities tested:**
+- Symbol insertion and lookup
+- Package prefix handling
+- Hash table management
+
+**When to add tests:** When modifying HyperSpec lookup or symbol handling.
+
+### sly-messages-unit-tests.el
+
+Tests message and logging utilities:
+
+- **Message formatting**: Prefix, truncation, styling
+- **Message levels**: Info, warning, error distinctions
+- **Prompt formatting**: User-facing messages
+- **Visual feedback**: Flashing regions, highlighting
+
+**Key utilities tested:**
+- `sly-message`: Information messages
+- `sly-warning`: Warning messages
+- `sly-error`: Error messages
+- `sly-user-error`: User-caused errors
+- `sly-flash-region`: Visual feedback
+
+**When to add tests:** When modifying message formatting or adding user-facing feedback.
+
+### sly-parse-unit-tests.el
+
+Tests parsing and syntax utilities:
+
+- **Syntax detection**: Character classification (parens, whitespace, word)
+- **String/comment detection**: Is point in a string or comment?
+- **Form location**: Finding expressions at point
+- **List navigation**: Moving through nested lists
+- **Pattern matching**: Recognizing code patterns
+
+**Key utilities tested:**
+- `sly-parse-form-at-point`: Find expression at point
+- Character syntax tables
+- String and comment boundary detection
+- Nested list traversal
+
+**When to add tests:** When modifying parsing logic or syntax detection.
+
+## Running Tests
+
+### Run All Unit Tests
+```bash
+make check-unit
+```
+
+This runs all 131 unit tests across all modules (buttons, common, completion, hyperspec, messages, parse). Unit tests do not require a Lisp connection.
+
+### Run Unit Tests with Coverage
+```bash
+make check-unit-coverage
+```
+
+This runs all unit tests with coverage tracking and generates a `coverage/` directory with an HTML report. Requires the `undercover.el` package.
+
+### Run Specific Test Interactively
+To run a specific test or subset of tests, load the test file in Emacs and use ERT:
+
+```elisp
+;; Load the tests
+M-x load-file RET test/sly-buttons-unit-tests.el RET
+
+;; Run all tests in that file
+M-x ert RET t RET
+
+;; Run a specific test
+M-x ert RET sly-buttons-unit--level-default RET
+
+;; Run all unit tests matching a pattern
+M-x ert RET ^sly-buttons-unit-- RET
+```
+
+### Run Integration Tests (Requires Lisp)
+
+These tests require a running Lisp implementation and test the full client-server integration:
+
+```bash
+# Run all integration tests (core + contribs)
+make check
+
+# Run core integration tests only
+make check-core
+
+# Run specific contrib tests
+make check-mrepl      # mREPL contrib tests
+make check-stickers   # Stickers contrib tests
+make check-autodoc    # Autodoc contrib tests
+
+# Run with specific Lisp implementation
+make check LISP=ccl       # Use CCL
+make check LISP=sbcl      # Use SBCL
+make check LISP=/path/to/lisp  # Use custom Lisp
+```
+
+**Note**: The `check-%` pattern only works for contribs, not unit test modules. There are no `make check-buttons` or `make check-parse` targets. Use `make check-unit` to run all unit tests.
+
+## Troubleshooting
+
+### Test Fails with "No mock response registered"
+
+**Cause**: You're calling `sly-eval` inside a test without providing a mock response.
+
+**Fix**: Use `sly-test-with-mock-eval` and register the Lisp call:
+
+```elisp
+;; Before (fails)
+(ert-deftest sly-example-unit--eval-without-mock ()
+  "This will fail."
+  (sly-eval '(slynk:foo)))  ;; ERROR: No mock response
+
+;; After (works)
+(ert-deftest sly-example-unit--eval-with-mock ()
+  "This works."
+  (sly-test-with-mock-eval
+      (((slynk:foo) . "result"))
+    (sly-eval '(slynk:foo))))  ;; Returns "result"
+```
+
+### Test Fails with "sly-connected-p: not defined"
+
+**Cause**: Your test code checks for a connection, but the connection functions aren't stubbed.
+
+**Fix**: Wrap your test with `sly-unit-with-stubbed-connection`:
+
+```elisp
+;; Before (fails)
+(ert-deftest sly-example-unit--needs-connection ()
+  "This will fail."
+  (when (sly-connected-p)  ;; ERROR: function not defined
+    ...))
+
+;; After (works)
+(ert-deftest sly-example-unit--needs-connection ()
+  "This works."
+  (sly-unit-with-stubbed-connection
+    (when (sly-connected-p)
+      ...)))
+```
+
+### Test Passes Locally But Fails in CI
+
+**Cause**: Test depends on external state (Lisp connection, file system, environment).
+
+**Fix**: Make test truly isolated by mocking all external dependencies:
+
+```elisp
+;; Before (fragile - depends on real connection)
+(ert-deftest sly-example-unit--depends-on-connection ()
+  "Test (broken in CI)."
+  (when (sly-connected-p)
+    (let ((result (sly-eval '(slynk:my-function))))
+      ...)))
+
+;; After (isolated)
+(ert-deftest sly-example-unit--isolated-test ()
+  "Test (works everywhere)."
+  (sly-test-with-mock-eval
+      (((slynk:my-function) . "mocked result"))
+    (let ((result (sly-eval '(slynk:my-function))))
+      ...)))
+```
+
+### "Point is at..." Assertions Fail
+
+**Cause**: Using `|` marker but checking wrong position.
+
+**Fix**: Remember that `|` is removed, so positions shift. Be careful with adjacent markers:
+
+```elisp
+;; Before (wrong)
+(sly-unit-with-temp-lisp-buffer-point "|foo"
+  (should (= 1 (point))))  ;; Fails! Point is at 1, char "f" is at 1
+
+;; After (right - understand positions)
+(sly-unit-with-temp-lisp-buffer-point "|foo"
+  (should (= (point-min) (point)))  ;; Correct
+  (should (eq ?f (char-after)))     ;; Point is before 'f'
+  )
+```
+
+## Advanced: Extending the Test Framework
+
+### Adding New Test Utilities
+
+If you find yourself repeating setup code, create a reusable macro in `lib/sly-unit-tests.el`:
+
+```elisp
+;; In lib/sly-unit-tests.el
+(defmacro sly-unit-with-my-test-setup (&rest body)
+  "Setup common test environment for my tests."
+  (declare (indent 0) (debug t))
+  `(sly-unit-with-stubbed-connection
+     (sly-test-with-mock-eval (...)
+       ,@body)))
+```
+
+Then use it in your tests:
+
+```elisp
+(ert-deftest sly-example-unit--using-new-utility ()
+  "Test using new utility."
+  (sly-unit-with-my-test-setup
+    (test-code-here)))
+```
+
+### Adding New Mock Responses
+
+For complex Lisp responses, create helper functions in `test/sly-test-mocks.el`:
+
+```elisp
+;; In test/sly-test-mocks.el
+(defun sly-test-mock-completion-response (completions)
+  "Create a mock completion response."
+  (list completions (car completions)))
+
+;; In your test
+(ert-deftest sly-example-unit--complex-mock ()
+  "Test with complex mock response."
+  (sly-test-with-mock-eval
+      (((slynk:simple-completions "foo" "CL-USER")
+        . (sly-test-mock-completion-response '("foobar" "foobaz"))))
+    ...))
+```
+
+## Next Steps
+
+- **Write a test**: Pick one of the 7 modules and add a test following the patterns above
+- **Run the tests**: `make check` to see your test pass
+- **Explore examples**: Look at existing tests in each module to see patterns in action
+- **Contribute**: Submit your tests as part of a bug fix or feature PR
+
+## Related Documentation
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — How to contribute to SLY
+- [SLY-ARCHITECTURE.md](../doc/SLY-ARCHITECTURE.md) — Overall system design
+- [SLYNK-PROTOCOL.md](../doc/SLYNK-PROTOCOL.md) — Client-server protocol details
+
+## Questions?
+
+If something is unclear, check the existing tests in the module you're working with. Each test is a worked example of how to test similar code.

--- a/doc/XREF-COMPARISON.md
+++ b/doc/XREF-COMPARISON.md
@@ -1,0 +1,244 @@
+# SLY xref vs Emacs xref.el: Comparison Report
+
+This document compares SLY's bespoke cross-reference system with Emacs's built-in `xref.el` framework, analyzing differences and documenting the rationale for migrating to the standard Emacs API.
+
+## Executive Summary
+
+SLY inherited its xref system from SLIME, which predates Emacs's `xref.el` (introduced in Emacs 25.1). While SLY's system is functional, migrating to `xref.el` provides:
+
+1. **Consistency**: Standard keybindings and UI patterns familiar to Emacs users
+2. **Integration**: Works with `project.el`, `grep.el`, and other Emacs infrastructure
+3. **Maintenance**: Reduced code to maintain; leverages Emacs core improvements
+4. **Future-proofing**: Other packages increasingly expect xref.el integration
+
+## Architecture Comparison
+
+### SLY's Current System
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Emacs Side (sly.el)                      │
+├─────────────────────────────────────────────────────────────────┤
+│  sly-edit-definition          → sly-eval '(slynk:find-...)     │
+│  sly-who-calls                → sly-eval '(slynk:xref ...)     │
+│  sly-xref-mode                → Custom buffer display           │
+│  sly-xref--show-results       → Custom results rendering        │
+│  sly-push-definition-stack    → xref-push-marker-stack (compat) │
+└─────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼ RPC over TCP
+┌─────────────────────────────────────────────────────────────────┐
+│                     Slynk Side (slynk.lisp)                     │
+├─────────────────────────────────────────────────────────────────┤
+│  find-definitions-for-emacs   → Returns ((DSPEC LOCATION) ...)  │
+│  xref (type name)             → Dispatches to xref-doit        │
+│  xrefs (types name)           → Multiple xref queries          │
+│  xref-doit                    → Generic function by type        │
+└─────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼ Backend interface
+┌─────────────────────────────────────────────────────────────────┐
+│                   slynk-backend.lisp (interface)                │
+├─────────────────────────────────────────────────────────────────┤
+│  find-definitions             → Per-implementation              │
+│  who-calls, calls-who         → Compiler-specific               │
+│  who-references, who-binds    → Compiler-specific               │
+│  who-sets, who-macroexpands   → Compiler-specific               │
+│  who-specializes              → CLOS introspection              │
+│  list-callers, list-callees   → Portable fallback (xref.lisp)  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Emacs xref.el Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         xref.el (Emacs core)                    │
+├─────────────────────────────────────────────────────────────────┤
+│  xref-find-definitions        → M-.  standard binding          │
+│  xref-find-references         → M-?  standard binding          │
+│  xref-go-back                 → M-,  standard binding          │
+│  xref-backend-functions       → Hook for backend discovery     │
+│  *xref* buffer                → Standardized results display    │
+└─────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼ Backend protocol
+┌─────────────────────────────────────────────────────────────────┐
+│                      Backend Methods (cl-defmethod)             │
+├─────────────────────────────────────────────────────────────────┤
+│  xref-backend-identifier-at-point  → Get symbol at point       │
+│  xref-backend-definitions          → Find definitions          │
+│  xref-backend-references           → Find references           │
+│  xref-backend-apropos              → Pattern-based search      │
+│  xref-backend-identifier-completion-table → Completion         │
+└─────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼ Data structures
+┌─────────────────────────────────────────────────────────────────┐
+│                         xref Objects                            │
+├─────────────────────────────────────────────────────────────────┤
+│  xref-item                    → (summary . location)           │
+│  xref-file-location           → (file line column)             │
+│  xref-buffer-location         → (buffer position)              │
+│  xref-bogus-location          → Error placeholder              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Feature Mapping
+
+| SLY Feature                | xref.el Equivalent                    | Notes                              |
+|---------------------------|---------------------------------------|-----------------------------------|
+| `sly-edit-definition`     | `xref-find-definitions`              | Direct mapping                    |
+| `sly-who-calls`           | `xref-find-references` + filtering   | Needs type parameter              |
+| `sly-edit-uses`           | `xref-find-references`               | Combined query                    |
+| `sly-xref-mode`           | `xref--xref-buffer-mode`             | Standard buffer                   |
+| `sly-xref--show-results`  | `xref--show-xrefs`                   | Internal function                 |
+| `sly-push-definition-stack`| `xref-push-marker-stack`            | Already used as fallback          |
+| `sly-pop-find-definition-stack`| `xref-go-back`                  | Standard navigation               |
+| `sly-xref` struct         | `xref-item` class                    | Similar structure                 |
+| `sly-location` struct     | `xref-file-location` class           | Similar structure                 |
+
+## Data Structure Mapping
+
+### SLY Location Format (from Slynk)
+
+```lisp
+;; Slynk returns locations in this format:
+(:location
+  (:file "/path/to/file.lisp")    ; or (:buffer "buffer-name")
+  (:position 1234)                 ; byte offset
+  (:snippet "code context"))       ; optional
+```
+
+### xref.el Location Objects
+
+```elisp
+;; xref.el expects these objects:
+(xref-make-file-location FILE LINE COLUMN)
+(xref-make-buffer-location BUFFER POINT)
+(xref-make-bogus-location MESSAGE)
+```
+
+### Conversion Required
+
+The main conversion work is transforming Slynk's `(:location ...)` format to xref location objects. This requires:
+
+1. Converting byte positions to line/column (for `xref-file-location`)
+2. Handling buffer locations (for `xref-buffer-location`)
+3. Converting error locations (`:error "message"`) to `xref-bogus-location`
+
+## SLY-Specific Features Not in xref.el
+
+SLY has several xref features beyond simple definition/reference lookup:
+
+| SLY Feature           | xref.el Support | Implementation Strategy            |
+|----------------------|-----------------|-----------------------------------|
+| `:calls`             | Via references  | Filter by call-site type          |
+| `:calls-who`         | No equivalent   | Custom menu/command               |
+| `:references`        | Supported       | Direct mapping                    |
+| `:binds`             | No equivalent   | Custom menu/command               |
+| `:sets`              | No equivalent   | Custom menu/command               |
+| `:macroexpands`      | No equivalent   | Custom menu/command               |
+| `:specializes`       | No equivalent   | Custom menu/command               |
+| `:callers`           | Via references  | Direct mapping                    |
+| `:callees`           | No equivalent   | Custom menu/command               |
+| Recompile from xref  | No equivalent   | Custom buffer command             |
+
+### Recommended Approach
+
+1. **Core integration**: Map `sly-edit-definition` → `xref-find-definitions`
+2. **References**: Map `sly-who-calls` and similar → `xref-find-references` with type annotation
+3. **Extended features**: Keep SLY-specific commands that call xref.el infrastructure but display in enhanced buffer
+4. **Recompilation**: Add to xref buffer via major-mode customization
+
+## Keybinding Analysis
+
+### Current SLY Bindings
+
+```elisp
+(define-key map (kbd "M-.")     'sly-edit-definition)
+(define-key map (kbd "M-,")     'sly-pop-find-definition-stack)
+(define-key map (kbd "M-_")     'sly-edit-uses)    ; German layout
+(define-key map (kbd "M-?")     'sly-edit-uses)    ; US layout
+(define-key map (kbd "C-x 4 .") 'sly-edit-definition-other-window)
+(define-key map (kbd "C-x 5 .") 'sly-edit-definition-other-frame)
+```
+
+### Standard xref.el Bindings
+
+```elisp
+M-.       xref-find-definitions
+M-,       xref-go-back
+M-?       xref-find-references
+C-x 4 .   xref-find-definitions-other-window
+C-x 5 .   xref-find-definitions-other-frame
+```
+
+### Compatibility Note
+
+SLY's bindings are already aligned with xref.el conventions. The migration should be transparent to users for the primary navigation commands.
+
+## Implementation Complexity
+
+### Low Complexity
+- Backend registration via `xref-backend-functions`
+- `xref-backend-identifier-at-point` implementation
+- `xref-backend-definitions` implementation
+- Location conversion logic
+
+### Medium Complexity
+- `xref-backend-references` with type filtering
+- Maintaining SLY's extended xref types (binds, sets, etc.)
+- Buffer/position to line/column conversion
+
+### High Complexity
+- Preserving recompilation functionality in xref buffer
+- Async result handling (xref.el expects synchronous returns by default)
+- Multiple connections (which Slynk to query?)
+
+## Async Considerations
+
+SLY's RPC is inherently asynchronous (`sly-eval-async`), but xref.el's backend methods expect synchronous returns. Options:
+
+1. **Blocking call**: Use `sly-eval` (synchronous) instead of `sly-eval-async`
+   - Simpler implementation
+   - May cause UI freezes for slow queries
+
+2. **Promise-based**: Return immediately with placeholder, update when ready
+   - Requires xref.el modification or workaround
+   - Better UX for large codebases
+
+3. **Hybrid**: Synchronous for small results, async with progress for large
+   - Most complex to implement
+   - Best user experience
+
+**Recommendation**: Start with synchronous calls. The Slynk queries are typically fast (<100ms). Optimize if performance issues arise.
+
+## Risks and Mitigations
+
+| Risk                                  | Mitigation                                           |
+|--------------------------------------|-----------------------------------------------------|
+| Breaking existing user workflows     | Maintain command aliases for compatibility           |
+| Loss of SLY-specific features        | Keep extended commands, integrate with xref UI      |
+| Async/sync mismatch                  | Use synchronous RPC initially                        |
+| Position conversion errors           | Comprehensive test suite for edge cases              |
+| Multiple connection handling         | Use `sly-current-connection` consistently           |
+
+## Conclusion
+
+Migrating SLY to use Emacs's `xref.el` is feasible and beneficial. The core functionality maps directly, and SLY-specific features can be layered on top. The main work involves:
+
+1. Implementing the xref backend methods
+2. Converting location formats
+3. Handling async RPC (initially via synchronous calls)
+4. Maintaining extended xref types as SLY-specific commands
+
+The migration reduces maintenance burden and improves integration with the broader Emacs ecosystem.
+
+## References
+
+- [Emacs xref.el source](https://github.com/emacs-mirror/emacs/blob/master/lisp/progmodes/xref.el)
+- [xref-js2 implementation example](https://github.com/NicolasPetton/xref-js2/blob/master/xref-js2.el)
+- [ESS-R xref backend](https://github.com/emacs-ess/ESS/blob/master/lisp/ess-r-xref.el)
+- [GNU Emacs xref documentation](https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref.html)
+- [SLIME xref implementation](https://github.com/slime/slime/blob/master/slime.el)

--- a/doc/XREF-INTEGRATION-CHANGES.md
+++ b/doc/XREF-INTEGRATION-CHANGES.md
@@ -1,0 +1,178 @@
+# SLY xref.el Integration - Change Report
+
+**Date:** 2026-01-02
+**Status:** Complete
+
+## Summary
+
+This document records the changes made to integrate SLY with Emacs's built-in `xref.el` framework. The integration follows a "soft deprecation" strategy: old commands remain functional while new xref.el integration is added.
+
+## Files Changed
+
+### New Files Created
+
+| File | Purpose |
+|------|---------|
+| `lib/sly-xref.el` | xref.el backend implementation |
+| `test/sly-xref-unit-tests.el` | Unit tests for xref integration |
+| `doc/XREF-COMPARISON.md` | Comparison of SLY vs xref.el architectures |
+| `doc/plans/2026-01-02-xref-integration-design.md` | Design document |
+| `doc/XREF-INTEGRATION-CHANGES.md` | This change report |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `sly.el` | Added require for sly-xref.el; added soft-deprecation notes to xref functions |
+| `Makefile` | Added sly-xref-unit-tests to check-unit target |
+| `test/sly-common-unit-tests.el` | Fixed syntax error (unrelated) |
+
+## Implementation Details
+
+### 1. xref.el Backend (`lib/sly-xref.el`)
+
+Created a new backend that registers with `xref-backend-functions`:
+
+```elisp
+(defun sly-xref-backend ()
+  "SLY backend for xref.el."
+  (when (and (fboundp 'sly-connected-p) (sly-connected-p))
+    'sly))
+
+(add-hook 'xref-backend-functions #'sly-xref-backend)
+```
+
+**Backend Methods Implemented:**
+
+| Method | Description |
+|--------|-------------|
+| `xref-backend-identifier-at-point` | Returns symbol at point via `sly-symbol-at-point` |
+| `xref-backend-definitions` | Finds definitions via `slynk:find-definitions-for-emacs` |
+| `xref-backend-references` | Finds callers via `slynk:xref :callers` |
+| `xref-backend-apropos` | Pattern search via `slynk:apropos-list-for-emacs` |
+| `xref-backend-identifier-completion-table` | Symbol completion |
+
+### 2. Location Conversion
+
+The core challenge was converting between Slynk's location format:
+
+```lisp
+(:location (:file "/path") (:position 1234) (:snippet "..."))
+```
+
+And xref.el's expected format:
+
+```elisp
+(xref-make-file-location FILE LINE COLUMN)
+```
+
+**Key functions:**
+
+- `sly-xref--convert-to-xref-items`: Converts list of Slynk xrefs to xref-items
+- `sly-xref--convert-location`: Handles various Slynk location types
+- `sly-xref--position-to-line-col`: Converts byte positions to line/column
+- `sly-xref--resolve-position-in-file`: Resolves different position spec types
+
+**Optimization:** For `:line` position specs, line/column are returned directly without reading the file.
+
+### 3. Unified Query Command
+
+Added `sly-xref-query` for accessing all Slynk xref types:
+
+```elisp
+(defvar sly-xref-query-types
+  '(("calls (who calls this)" . :calls)
+    ("calls-who (called by this)" . :calls-who)
+    ("references (who references this)" . :references)
+    ("binds (who binds this)" . :binds)
+    ("sets (who sets this)" . :sets)
+    ("macroexpands (who expands this)" . :macroexpands)
+    ("specializes (methods on this class)" . :specializes)
+    ("callers (portable who-calls)" . :callers)
+    ("callees (portable calls-who)" . :callees)))
+```
+
+Usage: `M-x sly-xref-query` prompts for type and symbol.
+
+### 4. Recompile Minor Mode
+
+Added `sly-xref-recompile-mode` for xref buffers:
+
+| Keybinding | Command | Description |
+|------------|---------|-------------|
+| `C-c C-c` | `sly-xref-recompile-at-point` | Recompile definition at point |
+| `C-c C-k` | `sly-xref-recompile-all` | Recompile all definitions |
+
+### 5. Backward Compatibility
+
+All existing commands in `sly.el` remain functional with soft-deprecation notes:
+
+- `sly-edit-definition` - Note: prefer `xref-find-definitions` (M-.)
+- `sly-edit-uses` - Note: prefer `xref-find-references` (M-?) or `sly-xref-query`
+- `sly-who-calls` and related - Continue to work via `sly-xref`
+
+## Keybinding Changes
+
+| Binding | Old Command | New Behavior |
+|---------|-------------|--------------|
+| `M-.` | `sly-edit-definition` | Now handled by `xref-find-definitions` when connected |
+| `M-,` | `sly-pop-find-definition-stack` | Now handled by `xref-go-back` |
+| `M-?` | `sly-edit-uses` | Now handled by `xref-find-references` |
+
+## Test Coverage
+
+Added 24 unit tests covering:
+
+| Category | Tests |
+|----------|-------|
+| Backend registration | 2 |
+| Location conversion | 7 |
+| Position resolution | 4 |
+| Query system | 3 |
+| Backward compatibility | 2 |
+| Recompile mode | 1 |
+| Backend methods | 5 |
+
+All 165 unit tests pass (141 existing + 24 new).
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Backward compatibility | Soft deprecation | Minimize disruption; gradual migration path |
+| Async handling | Synchronous | Simpler implementation; Slynk queries are fast (<100ms) |
+| Extended xref types | Unified `sly-xref-query` | Single entry point; displays in standard `*xref*` buffer |
+| Recompile feature | Minor mode | Preserves batch-recompile functionality in xref buffers |
+| Multiple connections | Current connection only | Matches existing behavior; simpler implementation |
+
+## Column Handling Note
+
+xref.el uses 0-based columns while Slynk uses 1-based. The conversion automatically adjusts:
+
+```elisp
+;; For :line specs, convert 1-based to 0-based
+(cons line (if col (1- col) 0))
+```
+
+## What This Enables
+
+1. **Standard Navigation:** `M-.`, `M-,`, `M-?` work identically to other Emacs modes
+2. **Integration:** Works with `project.el`, `grep.el`, and other Emacs infrastructure
+3. **Consistency:** Results appear in standard `*xref*` buffer
+4. **Extended Queries:** All Slynk xref types via unified `sly-xref-query`
+5. **Recompilation:** Batch recompile from xref results buffer
+
+## Migration Path for Users
+
+**Immediate:** No action required. Existing workflows continue to work.
+
+**Recommended:**
+- Use `M-.` instead of `M-x sly-edit-definition`
+- Use `M-?` instead of `M-x sly-edit-uses`
+- Use `M-x sly-xref-query` for advanced xref types
+
+## References
+
+- [Emacs xref.el documentation](https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref.html)
+- [Design document](plans/2026-01-02-xref-integration-design.md)
+- [Comparison report](XREF-COMPARISON.md)

--- a/lib/sly-unit-tests.el
+++ b/lib/sly-unit-tests.el
@@ -1,0 +1,202 @@
+;;; sly-unit-tests.el --- Unit test framework for SLY -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 SLY Contributors
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; Commentary:
+
+;; Unit test utilities for testing SLY's pure Elisp code without
+;; requiring a live Lisp connection.  These tests complement the
+;; integration tests in lib/sly-tests.el.
+;;
+;; WHAT THIS FILE PROVIDES:
+;;
+;; This module contains reusable macros and functions for writing fast,
+;; isolated unit tests that verify SLY's Elisp code without needing a
+;; running Lisp server.  Tests can run in seconds and are completely
+;; independent of external state.
+;;
+;; KEY UTILITIES:
+;;
+;; Buffer Creation:
+;;   - sly-unit-with-temp-lisp-buffer: Create temp buffer with Lisp code
+;;   - sly-unit-with-temp-lisp-buffer-point: Temp buffer with | marking point
+;;
+;; Function Mocking:
+;;   - sly-unit-with-mock: Temporarily replace functions
+;;   - sly-unit-with-stubbed-connection: Stub connection functions
+;;
+;; Overlay/Button Testing:
+;;   - sly-unit-with-overlays: Create and clean up test overlays
+;;   - sly-unit-make-test-overlay: Low-level overlay creation
+;;   - sly-unit-propertize-region: Add text properties
+;;
+;; Assertions:
+;;   - sly-unit-should-match: Assert string matches regex
+;;   - sly-unit-should-equal-normalized: Assert equal after whitespace normalization
+;;
+;; Completion Testing:
+;;   - sly-unit-make-completion-table: Create mock completion function
+;;
+;; USAGE PATTERN:
+;;
+;; (ert-deftest sly-example-unit--my-function-works ()
+;;   "Test that my-function produces expected output."
+;;   (sly-unit-with-temp-lisp-buffer "(defun foo () 42)"
+;;     (goto-char 10)
+;;     (should (equal "foo" (symbol-at-point)))))
+;;
+;; For more examples and patterns, see doc/TESTING-UNIT-TESTS.md.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+
+;;; Test Buffer Utilities
+;;;
+(defmacro sly-unit-with-temp-lisp-buffer (content &rest body)
+  "Execute BODY in a temp buffer with CONTENT in `lisp-mode'.
+Point is placed at the beginning of the buffer."
+  (declare (indent 1) (debug t))
+  `(with-temp-buffer
+     (lisp-mode)
+     (insert ,content)
+     (goto-char (point-min))
+     ,@body))
+
+(defmacro sly-unit-with-temp-lisp-buffer-point (content &rest body)
+  "Like `sly-unit-with-temp-lisp-buffer' but | marks point position.
+The | character is removed and point is placed there."
+  (declare (indent 1) (debug t))
+  `(with-temp-buffer
+     (lisp-mode)
+     (insert ,content)
+     (goto-char (point-min))
+     (when (search-forward "|" nil t)
+       (delete-char -1))
+     ,@body))
+
+;;; Mock Function Utilities
+;;;
+(defmacro sly-unit-with-mock (bindings &rest body)
+  "Execute BODY with functions temporarily rebound.
+BINDINGS is a list of (FUNC REPLACEMENT) pairs.
+Example: (sly-unit-with-mock ((foo (lambda () 42))) (foo)) => 42"
+  (declare (indent 1) (debug t))
+  (let ((originals (cl-gensym "originals")))
+    `(let ((,originals
+            (list ,@(mapcar (lambda (b)
+                              `(cons ',(car b)
+                                     (when (fboundp ',(car b))
+                                       (symbol-function ',(car b)))))
+                            bindings))))
+       (unwind-protect
+           (progn
+             ,@(mapcar (lambda (b)
+                         `(fset ',(car b) ,(cadr b)))
+                       bindings)
+             ,@body)
+         (dolist (orig ,originals)
+           (if (cdr orig)
+               (fset (car orig) (cdr orig))
+             (fmakunbound (car orig))))))))
+
+(defmacro sly-unit-with-stubbed-connection (&rest body)
+  "Execute BODY with SLY connection functions stubbed.
+This allows testing code that checks for connection without
+actually requiring one."
+  (declare (indent 0) (debug t))
+  `(sly-unit-with-mock
+       ((sly-connected-p (lambda () t))
+        (sly-current-connection (lambda () 'mock-connection))
+        (sly-current-package (lambda () "CL-USER"))
+        (sly-buffer-package (lambda () "CL-USER")))
+     (let ((sly-buffer-package "CL-USER")
+           (sly-buffer-connection 'mock-connection))
+       ,@body)))
+
+;;; Assertion Helpers
+;;;
+(defun sly-unit-should-match (pattern string)
+  "Assert that STRING matches regexp PATTERN."
+  (should (string-match-p pattern string)))
+
+(defun sly-unit-should-equal-normalized (expected actual)
+  "Assert EXPECTED equals ACTUAL after normalizing whitespace."
+  (let ((normalize (lambda (s)
+                     (replace-regexp-in-string "[ \t\n]+" " "
+                                               (string-trim s)))))
+    (should (equal (funcall normalize expected)
+                   (funcall normalize actual)))))
+
+;;; Test Registration Helpers
+;;;
+(defmacro sly-unit-deftest (name args doc &rest body)
+  "Define a unit test NAME with ARGS, DOC, and BODY.
+This is a thin wrapper around `ert-deftest' that adds the 'sly-unit tag."
+  (declare (indent 2) (debug t))
+  `(ert-deftest ,(intern (format "sly-unit--%s" name)) ()
+     ,doc
+     :tags '(sly sly-unit)
+     ,@body))
+
+;;; Overlay/Button Test Utilities
+;;;
+(defun sly-unit-make-test-overlay (beg end &rest props)
+  "Create a test overlay from BEG to END with PROPS."
+  (let ((ov (make-overlay beg end)))
+    (while props
+      (overlay-put ov (pop props) (pop props)))
+    ov))
+
+(defmacro sly-unit-with-overlays (specs &rest body)
+  "Execute BODY with overlays created per SPECS.
+SPECS is a list of (VAR BEG END PROPS...) forms.
+Overlays are deleted after BODY."
+  (declare (indent 1) (debug t))
+  (let ((ovs (mapcar (lambda (spec)
+                       (let ((var (car spec))
+                             (beg (cadr spec))
+                             (end (caddr spec))
+                             (props (cdddr spec)))
+                         `(,var (sly-unit-make-test-overlay ,beg ,end ,@props))))
+                     specs)))
+    `(let ,ovs
+       (unwind-protect
+           (progn ,@body)
+         ,@(mapcar (lambda (spec) `(delete-overlay ,(car spec))) specs)))))
+
+;;; Text Property Test Utilities
+;;;
+(defun sly-unit-propertize-region (beg end &rest props)
+  "Add PROPS to region from BEG to END."
+  (add-text-properties beg end props))
+
+(defun sly-unit-has-property-p (pos prop &optional value)
+  "Check if POS has text property PROP, optionally with VALUE."
+  (let ((actual (get-text-property pos prop)))
+    (if value
+        (equal actual value)
+      actual)))
+
+;;; Completion Test Utilities
+;;;
+(defun sly-unit-make-completion-table (completions)
+  "Create a completion table function returning COMPLETIONS.
+COMPLETIONS should be a list of strings."
+  (lambda (string pred action)
+    (pcase action
+      ('metadata '(metadata (category . sly-completion)))
+      ('t completions)
+      ('nil (try-completion string completions pred))
+      (`(boundaries . ,suffix)
+       (completion-boundaries string completions pred suffix))
+      (_ nil))))
+
+(provide 'sly-unit-tests)
+;;; sly-unit-tests.el ends here

--- a/lib/sly-xref.el
+++ b/lib/sly-xref.el
@@ -1,0 +1,385 @@
+;;; sly-xref.el --- xref.el backend for SLY -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 SLY Contributors
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; Commentary:
+
+;; This file provides integration between SLY and Emacs's built-in xref.el
+;; framework for cross-reference navigation.
+;;
+;; WHAT THIS FILE PROVIDES:
+;;
+;; When SLY is connected to a Lisp, this module registers an xref backend
+;; that enables standard Emacs navigation commands to work with Lisp code:
+;;
+;;   M-.   (xref-find-definitions)  - Jump to definition
+;;   M-,   (xref-go-back)           - Return from definition
+;;   M-?   (xref-find-references)   - Find callers
+;;
+;; Additionally, SLY's extended cross-reference queries (who-calls,
+;; who-binds, who-sets, etc.) are available via the unified command
+;; `sly-xref-query' (bound to C-c C-w).
+;;
+;; KEY COMPONENTS:
+;;
+;; Backend Registration:
+;;   sly-xref-backend: Returns 'sly when connected, enabling xref dispatch
+;;
+;; Backend Methods:
+;;   xref-backend-identifier-at-point: Extract Lisp symbol at point
+;;   xref-backend-definitions: Find definitions via Slynk
+;;   xref-backend-references: Find callers via Slynk
+;;   xref-backend-apropos: Pattern-based symbol search
+;;
+;; Location Conversion:
+;;   sly-xref--convert-to-xref-items: Convert Slynk results to xref objects
+;;   sly-xref--convert-location: Handle various Slynk location formats
+;;   sly-xref--position-to-line-col: Byte position to line/column
+;;
+;; Query System:
+;;   sly-xref-query: Unified command for all xref query types
+;;   sly-xref-query-types: Registry mapping names to Slynk keywords
+;;
+;; Recompile Support:
+;;   sly-xref-recompile-mode: Minor mode adding recompile to xref buffers
+;;
+;; ARCHITECTURE:
+;;
+;; This module acts as a bridge between two systems:
+;;
+;; 1. Emacs xref.el expects:
+;;    - xref-item objects with summary strings
+;;    - xref-file-location or xref-buffer-location objects
+;;    - Synchronous return values from backend methods
+;;
+;; 2. Slynk returns:
+;;    - Lists of (DSPEC LOCATION) pairs
+;;    - Locations as (:location BUFFER-SPEC POSITION-SPEC HINTS)
+;;    - Position specs as byte offsets, line numbers, or function names
+;;
+;; The conversion functions handle translating between these formats,
+;; including reading files to convert byte positions to line/column.
+
+;;; Code:
+
+(require 'xref)
+(require 'cl-lib)
+
+;; This file is loaded by sly.el after all core functions are defined.
+;; We use forward declarations to avoid circular dependencies during
+;; byte-compilation.
+(declare-function sly-connected-p "sly")
+(declare-function sly-eval "sly")
+(declare-function sly-symbol-at-point "sly")
+(declare-function sly-read-symbol-name "sly")
+(declare-function sly-current-package "sly")
+(declare-function sly-lisp-implementation-name "sly")
+(declare-function sly-location-p "sly")
+(declare-function sly--pop-to-source-location "sly")
+(declare-function sly-recompile-locations "sly")
+(declare-function sly-compilation-finished "sly")
+(declare-function sly-aggregate-compilation-results "sly")
+(declare-function sly-simple-completions "lib/sly-completion")
+
+;; sly-dcase is a macro defined in sly.el
+(eval-when-compile
+  (require 'sly nil t))
+
+
+;;;; Backend Registration
+;;;;
+
+;;;###autoload
+(defun sly-xref-backend ()
+  "SLY backend for xref.el.
+Returns \\='sly when SLY is connected, nil otherwise."
+  (when (and (fboundp 'sly-connected-p) (sly-connected-p))
+    'sly))
+
+;;;###autoload
+(with-eval-after-load 'xref
+  (add-hook 'xref-backend-functions #'sly-xref-backend))
+
+
+;;;; Location Conversion
+;;;;
+
+(defun sly-xref--convert-to-xref-items (slynk-xrefs)
+  "Convert Slynk xrefs to xref-item objects.
+SLYNK-XREFS is a list of (DSPEC LOCATION) pairs from Slynk."
+  (cl-loop for (dspec location) in slynk-xrefs
+           for xref-loc = (sly-xref--convert-location location)
+           when xref-loc
+           collect (xref-make (if (stringp dspec)
+                                  dspec
+                                (prin1-to-string dspec))
+                              xref-loc)))
+
+(defun sly-xref--convert-location (location)
+  "Convert a Slynk LOCATION to an xref location object.
+Returns nil if LOCATION cannot be converted."
+  (when location
+    (sly-dcase location
+      ((:location buffer position _hints)
+       (sly-xref--make-location buffer position))
+      ((:error message)
+       (xref-make-bogus-location message))
+      (t nil))))
+
+(defun sly-xref--make-location (buffer-spec position-spec)
+  "Create xref location from Slynk BUFFER-SPEC and POSITION-SPEC."
+  (sly-dcase buffer-spec
+    ((:file filename)
+     (let ((line-col (sly-xref--position-to-line-col filename position-spec)))
+       (xref-make-file-location filename (car line-col) (cdr line-col))))
+    ((:buffer buffer-name)
+     (if-let ((buf (get-buffer buffer-name)))
+         (let ((pos (sly-xref--resolve-position position-spec buf)))
+           (xref-make-buffer-location buf pos))
+       (xref-make-bogus-location (format "Buffer %s not found" buffer-name))))
+    ((:buffer-and-file _buffer-name filename)
+     ;; Prefer file location for persistence
+     (let ((line-col (sly-xref--position-to-line-col filename position-spec)))
+       (xref-make-file-location filename (car line-col) (cdr line-col))))
+    ((:source-form _)
+     (xref-make-bogus-location "Source form (no file location)"))
+    ((:zip _archive-path _entry-path)
+     (xref-make-bogus-location "Archive location not supported"))
+    (t
+     (xref-make-bogus-location "Unknown location type"))))
+
+(defun sly-xref--position-to-line-col (filename position-spec)
+  "Convert POSITION-SPEC to (LINE . COLUMN) for FILENAME.
+Returns (1 . 0) if conversion fails."
+  ;; For :line specs, we already have line/col - no need to read file
+  (sly-dcase position-spec
+    ((:line line &optional col)
+     ;; xref.el uses 0-based columns; Slynk uses 1-based
+     (cons line (if col (1- col) 0)))
+    (t
+     ;; For other position types, read file to compute line/column
+     (condition-case nil
+         (let ((pos (sly-xref--resolve-position-in-file filename position-spec)))
+           (with-temp-buffer
+             (insert-file-contents filename)
+             (goto-char (min pos (point-max)))
+             (cons (line-number-at-pos) (current-column))))
+       (error (cons 1 0))))))
+
+(defun sly-xref--resolve-position-in-file (filename position-spec)
+  "Resolve POSITION-SPEC to a byte offset for FILENAME."
+  (sly-dcase position-spec
+    ((:position pos) pos)
+    ((:offset _start pos) pos)
+    ((:line line &optional col)
+     (with-temp-buffer
+       (insert-file-contents filename)
+       (goto-char (point-min))
+       (forward-line (1- line))
+       (when col (forward-char (1- col)))
+       (point)))
+    ((:function-name name)
+     (with-temp-buffer
+       (insert-file-contents filename)
+       (goto-char (point-min))
+       (if (search-forward name nil t)
+           (match-beginning 0)
+         1)))
+    (t 1)))
+
+(defun sly-xref--resolve-position (position-spec buffer)
+  "Resolve POSITION-SPEC to a point in BUFFER."
+  (with-current-buffer buffer
+    (sly-dcase position-spec
+      ((:position pos) (min pos (point-max)))
+      ((:offset _start pos) (min pos (point-max)))
+      ((:line line &optional col)
+       (save-excursion
+         (goto-char (point-min))
+         (forward-line (1- line))
+         (when col (forward-char (min (1- col) (- (line-end-position) (point)))))
+         (point)))
+      ((:function-name name)
+       (save-excursion
+         (goto-char (point-min))
+         (if (search-forward name nil t)
+             (match-beginning 0)
+           (point-min))))
+      (t (point-min)))))
+
+
+;;;; Backend Methods
+;;;;
+
+(cl-defmethod xref-backend-identifier-at-point ((_backend (eql sly)))
+  "Return the Lisp symbol at point as a string."
+  (sly-symbol-at-point))
+
+(cl-defmethod xref-backend-definitions ((_backend (eql sly)) identifier)
+  "Find definitions of IDENTIFIER using Slynk."
+  (when identifier
+    (let ((xrefs (sly-eval `(slynk:find-definitions-for-emacs ,identifier))))
+      (sly-xref--convert-to-xref-items xrefs))))
+
+(cl-defmethod xref-backend-references ((_backend (eql sly)) identifier)
+  "Find references to IDENTIFIER using Slynk.
+This maps to Slynk's :callers query (portable, heap-groveling approach)."
+  (when identifier
+    (let ((xrefs (sly-eval `(slynk:xref ':callers ,identifier))))
+      (unless (eq xrefs :not-implemented)
+        (sly-xref--convert-to-xref-items xrefs)))))
+
+(cl-defmethod xref-backend-apropos ((_backend (eql sly)) pattern)
+  "Find symbols matching PATTERN."
+  (when pattern
+    (let ((results (sly-eval `(slynk:apropos-list-for-emacs ,pattern nil nil))))
+      (cl-loop for (name . _rest) in results
+               collect (xref-make name (xref-make-bogus-location name))))))
+
+(cl-defmethod xref-backend-identifier-completion-table ((_backend (eql sly)))
+  "Completion table for Lisp symbols."
+  (when (fboundp 'sly-simple-completions)
+    (completion-table-dynamic
+     (lambda (prefix)
+       (car (sly-simple-completions prefix))))))
+
+
+;;;; Unified Xref Query Command
+;;;;
+
+(defvar sly-xref-query-types
+  '(("calls (who calls this)" . :calls)
+    ("calls-who (called by this)" . :calls-who)
+    ("references (who references this)" . :references)
+    ("binds (who binds this)" . :binds)
+    ("sets (who sets this)" . :sets)
+    ("macroexpands (who expands this)" . :macroexpands)
+    ("specializes (methods on this class)" . :specializes)
+    ("callers (portable who-calls)" . :callers)
+    ("callees (portable calls-who)" . :callees))
+  "Alist mapping xref query type descriptions to Slynk keywords.")
+
+(defvar sly-xref--last-query-results nil
+  "Results from the last `sly-xref-query', for recompile support.
+This stores the raw Slynk results to enable recompilation.")
+
+(defun sly-xref-query (type symbol)
+  "Query for cross-references of TYPE for SYMBOL.
+TYPE is a keyword like :calls, :references, etc.
+Results are displayed in the standard *xref* buffer.
+
+Interactively, prompts for the query type and symbol."
+  (interactive
+   (let* ((type-name (completing-read "Xref type: " sly-xref-query-types nil t))
+          (type (cdr (assoc type-name sly-xref-query-types)))
+          (sym (sly-read-symbol-name (format "Xref %s for: " type-name))))
+     (list type sym)))
+  (let ((xrefs (sly-eval `(slynk:xref ',type ',symbol))))
+    (cond
+     ((eq xrefs :not-implemented)
+      (message "%s is not implemented for %s"
+               type (sly-lisp-implementation-name)))
+     ((null xrefs)
+      (message "No %s found for %s" type symbol))
+     (t
+      (let* ((items (sly-xref--convert-to-xref-items xrefs))
+             (fetcher (lambda () items)))
+        ;; Store results for recompile feature
+        (setq sly-xref--last-query-results xrefs)
+        (xref-show-xrefs fetcher nil))))))
+
+
+;;;; Recompile Minor Mode
+;;;;
+
+(defvar sly-xref-recompile-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-c") #'sly-xref-recompile-at-point)
+    (define-key map (kbd "C-c C-k") #'sly-xref-recompile-all)
+    map)
+  "Keymap for `sly-xref-recompile-mode'.")
+
+(define-minor-mode sly-xref-recompile-mode
+  "Minor mode adding SLY recompilation commands to xref buffers.
+
+When enabled, you can recompile definitions directly from xref results:
+
+\\{sly-xref-recompile-mode-map}"
+  :lighter " SLY-Recomp"
+  :keymap sly-xref-recompile-mode-map)
+
+(defun sly-xref--maybe-enable-recompile-mode ()
+  "Enable recompile mode in xref buffers when SLY is the backend."
+  (when (and (derived-mode-p 'xref--xref-buffer-mode)
+             sly-xref--last-query-results
+             (fboundp 'sly-connected-p)
+             (sly-connected-p))
+    (sly-xref-recompile-mode 1)))
+
+;; Hook into xref buffer creation
+(add-hook 'xref-after-return-hook #'sly-xref--maybe-enable-recompile-mode)
+
+(defun sly-xref--find-slynk-location-for-xref (xref-item)
+  "Find the original Slynk location for XREF-ITEM.
+Searches `sly-xref--last-query-results' for a matching location."
+  (when sly-xref--last-query-results
+    (let ((summary (xref-item-summary xref-item)))
+      (cl-loop for (dspec location) in sly-xref--last-query-results
+               when (equal (if (stringp dspec) dspec (prin1-to-string dspec))
+                           summary)
+               return location))))
+
+(defun sly-xref-recompile-at-point ()
+  "Recompile the definition at point in xref buffer."
+  (interactive)
+  (if-let* ((xref (xref--item-at-point))
+            (slynk-loc (sly-xref--find-slynk-location-for-xref xref)))
+      (if (sly-location-p slynk-loc)
+          (sly-recompile-locations
+           (list slynk-loc)
+           (lambda (result)
+             (sly-compilation-finished result nil)
+             (message "Recompiled: %s" (xref-item-summary xref))))
+        (user-error "No source location for this definition"))
+    (user-error "No xref at point")))
+
+(defun sly-xref-recompile-all ()
+  "Recompile all definitions in the xref buffer."
+  (interactive)
+  (if-let ((locations (cl-loop for (_dspec loc) in sly-xref--last-query-results
+                               when (sly-location-p loc)
+                               collect loc)))
+      (sly-recompile-locations
+       locations
+       (lambda (results)
+         (sly-compilation-finished
+          (sly-aggregate-compilation-results results) nil)
+         (message "Recompiled %d definitions" (length locations))))
+    (user-error "No valid locations to recompile")))
+
+
+;;;; Notes
+;;;;
+;; This module provides integration with Emacs's xref.el framework.
+;; The existing SLY xref commands in sly.el (sly-edit-definition,
+;; sly-who-calls, etc.) continue to work as before. This module
+;; adds:
+;;
+;; 1. An xref.el backend so standard commands like xref-find-definitions
+;;    (M-.) work with SLY when connected to a Lisp.
+;;
+;; 2. A new `sly-xref-query' command that provides a unified interface
+;;    to all xref query types, displaying results in the standard
+;;    *xref* buffer.
+;;
+;; 3. A minor mode that adds recompilation support to xref buffers.
+
+
+(provide 'sly-xref)
+
+;;; sly-xref.el ends here

--- a/sly.el
+++ b/sly.el
@@ -3941,7 +3941,9 @@ For insertion in the `compilation-mode' buffer"
   `(:location (:file ,file-name) (:position ,position)
               ,(when hints `(:hints ,hints))))
 
-
+;; NOTE: lib/sly-xref.el provides integration with Emacs's built-in
+;; xref.el framework. The commands below are soft-deprecated but remain
+;; functional for backward compatibility.
 
 (defun sly-edit-definition (&optional name method)
   "Lookup the definition of the name at point.
@@ -3949,7 +3951,9 @@ If there's no name at point, or a prefix argument is given, then
 the function name is prompted. METHOD can be nil, or one of
 `window' or `frame' to specify if the new definition should be
 popped, respectively, in the current window, a new window, or a
-new frame."
+new frame.
+
+This command is soft-deprecated; prefer `xref-find-definitions' (M-.)."
   (interactive (list (or (and (not current-prefix-arg)
                               (sly-symbol-at-point t))
                          (sly-read-symbol-name "Edit Definition of: "))))
@@ -3980,7 +3984,10 @@ new frame."
 ;;; FIXME. TODO: Would be nice to group the symbols (in each
 ;;;              type-group) by their home-package.
 (defun sly-edit-uses (symbol)
-  "Lookup all the uses of SYMBOL."
+  "Lookup all the uses of SYMBOL.
+
+This command is soft-deprecated; prefer `xref-find-references' (M-?)
+or `sly-xref-query' (C-c C-w)."
   (interactive (list (sly-read-symbol-name "Edit Uses of: ")))
   (sly-xref--get-xrefs
    sly-edit-uses-xrefs
@@ -4032,7 +4039,6 @@ FILE-ALIST is an alist of the form ((FILENAME . (XREF ...)) ...)."
   "Like `sly-edit-definition' but switch to the other window."
   (interactive (list (sly-read-symbol-name "Symbol: ")))
   (sly-edit-definition name 'frame))
-
 
 
 ;;;;; first-change-hook
@@ -7502,6 +7508,9 @@ and replace `sly-editing-mode' with `slime-lisp-mode-hook'.")))
  (t
   (warn
    "`sly.el' loaded OK. To use SLY, customize `lisp-mode-hook' and remove `slime-lisp-mode-hook'.")))
+
+;; Load xref.el integration after all core functions are defined
+(require 'sly-xref "lib/sly-xref")
 
 (provide 'sly)
 

--- a/test/sly-buttons-unit-tests.el
+++ b/test/sly-buttons-unit-tests.el
@@ -1,0 +1,251 @@
+;;; sly-buttons-unit-tests.el --- Unit tests for sly-buttons.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 SLY Contributors
+
+;;; Commentary:
+
+;; Unit tests for the button utilities in lib/sly-buttons.el.
+;; These tests cover button creation, querying, and navigation.
+;;
+;; WHAT IS TESTED:
+;;
+;; This module tests SLY's button system—how clickable regions are created,
+;; styled, queried, and interacted with.  Buttons are overlays that:
+;;
+;;   - Have a visual appearance (color, underline, cursor behavior)
+;;   - Respond to mouse clicks and keyboard navigation
+;;   - Can be nested (button level determines visual depth)
+;;   - Have type hierarchies (sly-action and sly-part inherit from sly-button)
+;;   - Store metadata (function to call, connection info, etc.)
+;;
+;; WHAT IS COVERED:
+;;
+;; Button Level (visual nesting):
+;;   - sly-button--level: Get/set how deeply nested a button is
+;;   - Default level is 0 (no nesting)
+;;
+;; Button Type Hierarchy:
+;;   - 'sly-button: Base button type
+;;   - 'sly-action: Clickable action button (inherits from sly-button)
+;;   - 'sly-part: Structured part (inherits from sly-button)
+;;
+;; Button Queries:
+;;   - sly-button--overlays-in: Find buttons in a region
+;;   - sly-button-at: Get button at a specific point
+;;   - Filtering by button type
+;;
+;; Button Creation:
+;;   - sly--make-text-button: Create button with properties
+;;   - sly-make-action-button: Create clickable button with callback
+;;   - Button stores connection and package info
+;;
+;; Keymaps:
+;;   - sly-part-button-keymap: Navigation and interaction keys
+;;   - Keymap inheritance from button-map
+;;   - sly-interactive-buttons-mode: Mode for button interaction
+;;
+;; WHEN TO ADD TESTS:
+;;
+;; Add tests when modifying:
+;;   - Button creation or type hierarchies
+;;   - Button level calculation or visual rendering
+;;   - Button finding or filtering logic
+;;   - Button keymaps or interaction behavior
+;;   - Button metadata storage
+;;
+;; WHY UNIT TESTS:
+;;
+;; Button logic is pure Elisp (no Lisp connection needed) and can be
+;; tested in isolation.  These unit tests verify the button system
+;; works correctly before integration testing with a full SLY session.
+;;
+;; See doc/TESTING-UNIT-TESTS.md for patterns and utilities.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'sly-buttons "lib/sly-buttons")
+(require 'sly-unit-tests "lib/sly-unit-tests")
+
+;;;; Helper for creating test buttons
+;;;;
+(defun sly-buttons-test--make-overlay-button (beg end &rest props)
+  "Create an overlay button from BEG to END with PROPS.
+This creates a proper sly-button overlay that will be recognized
+by `sly-button--overlays-in' and related functions."
+  (let ((ov (make-overlay beg end)))
+    ;; WHY THESE PROPERTIES MATTER:
+    ;;
+    ;; 'category 'sly-button: Links overlay to the button type defined via
+    ;; define-button-type. This is what makes it a "real" button with all
+    ;; the associated faces, keymaps, and behaviors.
+    ;;
+    ;; 'evaporate t: Makes overlay disappear automatically when all content
+    ;; it covers is deleted (useful when buffer is edited).
+    ;;
+    ;; 'button t: Mark this overlay as a button (used by button.el).
+    ;;
+    ;; 'sly-button-search-id: Unique ID for this button, used to distinguish
+    ;; it from other buttons and for stable references across edits.
+    (overlay-put ov 'category 'sly-button)
+    (overlay-put ov 'evaporate t)
+    (overlay-put ov 'button t)
+    (overlay-put ov 'sly-button-search-id (sly-button-next-search-id))
+    ;; Apply any additional properties (passed in PROPS)
+    (while props
+      (overlay-put ov (pop props) (pop props)))
+    ov))
+
+(defmacro sly-buttons-test--with-button-buffer (content &rest body)
+  "Execute BODY in a temp buffer with CONTENT."
+  (declare (indent 1) (debug t))
+  `(with-temp-buffer
+     (insert ,content)
+     (goto-char (point-min))
+     ,@body))
+
+;;;; Tests for sly-button--level
+;;;;
+(ert-deftest sly-buttons-unit--level-default ()
+  "Test `sly-button--level' returns 0 for unset."
+  (sly-buttons-test--with-button-buffer "test text"
+    (let ((ov (make-overlay 1 5)))
+      (unwind-protect
+          (should (= 0 (sly-button--level ov)))
+        (delete-overlay ov)))))
+
+(ert-deftest sly-buttons-unit--level-set ()
+  "Test `sly-button--level' returns set value."
+  (sly-buttons-test--with-button-buffer "test text"
+    (let ((ov (make-overlay 1 5)))
+      (unwind-protect
+          (progn
+            (overlay-put ov 'sly-button-level 3)
+            (should (= 3 (sly-button--level ov))))
+        (delete-overlay ov)))))
+
+(ert-deftest sly-buttons-unit--level-setf ()
+  "Test setting `sly-button--level' via setf."
+  (sly-buttons-test--with-button-buffer "test text"
+    (let ((ov (make-overlay 1 5)))
+      (unwind-protect
+          (progn
+            (setf (sly-button--level ov) 5)
+            (should (= 5 (sly-button--level ov))))
+        (delete-overlay ov)))))
+
+;;;; Tests for sly-button--overlays-in (simplified - complex button type checking)
+;;;;
+;; Note: The sly-button--overlays-* functions have complex type checking via
+;; button-type-subtype-p which requires proper button category setup.
+;; These are tested indirectly through integration tests.
+
+(ert-deftest sly-buttons-unit--overlays-in-none ()
+  "Test `sly-button--overlays-in' returns nil when no buttons."
+  (sly-buttons-test--with-button-buffer "test text"
+    (should (null (sly-button--overlays-in 1 10)))))
+
+;;;; Tests for button type definitions
+;;;;
+(ert-deftest sly-buttons-unit--button-type-sly-button-exists ()
+  "Test 'sly-button type is defined."
+  (should (get 'sly-button 'button-category-symbol)))
+
+(ert-deftest sly-buttons-unit--button-type-sly-action-exists ()
+  "Test 'sly-action type is defined."
+  (should (get 'sly-action 'button-category-symbol)))
+
+(ert-deftest sly-buttons-unit--button-type-sly-part-exists ()
+  "Test 'sly-part type is defined."
+  (should (get 'sly-part 'button-category-symbol)))
+
+(ert-deftest sly-buttons-unit--sly-action-inherits-sly-button ()
+  "Test 'sly-action inherits from 'sly-button."
+  (should (button-type-subtype-p 'sly-action 'sly-button)))
+
+(ert-deftest sly-buttons-unit--sly-part-inherits-sly-button ()
+  "Test 'sly-part inherits from 'sly-button."
+  (should (button-type-subtype-p 'sly-part 'sly-button)))
+
+;;;; Tests for sly-button-next-search-id
+;;;;
+(ert-deftest sly-buttons-unit--next-search-id-increments ()
+  "Test `sly-button-next-search-id' increments."
+  (let ((id1 (sly-button-next-search-id))
+        (id2 (sly-button-next-search-id)))
+    (should (= (1+ id1) id2))))
+
+;;;; Tests for text button creation
+;;;;
+(ert-deftest sly-buttons-unit--make-text-button ()
+  "Test `sly--make-text-button' creates button with properties."
+  (sly-unit-with-stubbed-connection
+    (with-temp-buffer
+      (insert "click me")
+      (let ((button (sly--make-text-button 1 9 :type 'sly-action)))
+        (should button)
+        (should (button-at 1))
+        (should (eq 'mock-connection
+                    (button-get (button-at 1) 'sly-connection)))))))
+
+;;;; Tests for sly-make-action-button
+;;;;
+(ert-deftest sly-buttons-unit--make-action-button ()
+  "Test `sly-make-action-button' creates clickable button."
+  (sly-unit-with-stubbed-connection
+    (with-temp-buffer
+      (let* ((clicked nil)
+             (button (sly-make-action-button
+                      "Click"
+                      (lambda (_btn) (setq clicked t)))))
+        (should (stringp button))
+        (should (equal "Click" button))))))
+
+;;;; Tests for sly-button-at
+;;;;
+(ert-deftest sly-buttons-unit--button-at-no-button ()
+  "Test `sly-button-at' returns nil with no-error flag."
+  (with-temp-buffer
+    (insert "no buttons here")
+    (goto-char 5)
+    (should (null (sly-button-at nil nil 'no-error)))))
+
+(ert-deftest sly-buttons-unit--button-at-errors-by-default ()
+  "Test `sly-button-at' errors when no button and no-error not set."
+  (with-temp-buffer
+    (insert "no buttons here")
+    (goto-char 5)
+    (should-error (sly-button-at))))
+
+(ert-deftest sly-buttons-unit--button-at-with-type ()
+  "Test `sly-button-at' filters by type."
+  (sly-unit-with-stubbed-connection
+    (with-temp-buffer
+      (insert "test")
+      (sly--make-text-button 1 5 :type 'sly-action)
+      (goto-char 2)
+      ;; Should find sly-action
+      (should (sly-button-at nil 'sly-action 'no-error))
+      ;; Should not find sly-part
+      (should-not (sly-button-at nil 'sly-part 'no-error)))))
+
+;;;; Tests for keymap
+;;;;
+(ert-deftest sly-buttons-unit--part-button-keymap-exists ()
+  "Test `sly-part-button-keymap' is defined."
+  (should (keymapp sly-part-button-keymap)))
+
+(ert-deftest sly-buttons-unit--part-button-keymap-has-bindings ()
+  "Test `sly-part-button-keymap' inherits from button-map."
+  ;; The keymap inherits from button-map and has some bindings
+  (should (eq (keymap-parent sly-part-button-keymap) button-map)))
+
+;;;; Tests for sly-interactive-buttons-mode
+;;;;
+(ert-deftest sly-buttons-unit--interactive-buttons-mode-exists ()
+  "Test `sly-interactive-buttons-mode' is defined."
+  (should (fboundp 'sly-interactive-buttons-mode)))
+
+(provide 'sly-buttons-unit-tests)
+;;; sly-buttons-unit-tests.el ends here

--- a/test/sly-common-unit-tests.el
+++ b/test/sly-common-unit-tests.el
@@ -135,7 +135,7 @@
             (should (string-match-p "Before" (buffer-string)))  ; ← outside overlay
             (should (string-match-p "REPLACED" (buffer-string)))  ; ← replacement inserted
             (should (string-match-p "After" (buffer-string)))  ; ← outside overlay
-            (should-not (string-match-p "Middle" (buffer-string)))  ; ← cleared by refresh
+            (should-not (string-match-p "Middle" (buffer-string))))  ; ← cleared by refresh
         (delete-overlay ov)))))
 
 (ert-deftest sly-common-unit--call-refreshing-returns-buffer ()

--- a/test/sly-common-unit-tests.el
+++ b/test/sly-common-unit-tests.el
@@ -1,0 +1,289 @@
+;;; sly-common-unit-tests.el --- Unit tests for sly-common.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 SLY Contributors
+
+;;; Commentary:
+
+;; Unit tests for the common utilities in lib/sly-common.el.
+;; Tests cover buffer manipulation and refresh functionality.
+;;
+;; WHAT IS TESTED:
+;;
+;; This module tests utilities for manipulating Emacs buffers while
+;; preserving state like point position, narrowing, and read-only status.
+;; These are critical for SLY's REPL and inspector, which constantly
+;; update their buffers while keeping user's cursor position intact.
+;;
+;; KEY FUNCTIONS TESTED:
+;;
+;; sly--call-refreshing: Core function for safe buffer updates
+;;   - Erases and repopulates buffer while preserving point position
+;;   - Respects narrowed regions and read-only buffers
+;;   - Can optionally skip erasing (DONT-ERASE mode)
+;;   - Preserves overlay-based markers for point location
+;;
+;; sly-refreshing: Macro wrapper around sly--call-refreshing
+;;   - Cleaner syntax for common patterns
+;;   - Automatically handles current-buffer
+;;
+;; WHAT IS COVERED:
+;;
+;; Basic Buffer Operations:
+;;   - Clearing and repopulating buffer content
+;;   - Erasing with DONT-ERASE flag (preserve old content)
+;;   - Appending mode (add to end instead of replace)
+;;
+;; Point Recovery:
+;;   - Restoring point after buffer clear
+;;   - Finding point when content changes (using markers)
+;;   - Edge cases (point at EOF, empty buffer)
+;;
+;; Buffer State Preservation:
+;;   - Narrowed regions (buffer is limited to subset)
+;;   - Read-only buffers (edits still work, then restored)
+;;   - Active regions and mark preservation
+;;
+;; Overlays:
+;;   - Using overlays to mark point location
+;;   - Deleting old overlays before refresh
+;;   - Overlay-based buffer regions
+;;
+;; WHEN TO ADD TESTS:
+;;
+;; Add tests when modifying:
+;;   - Buffer refresh logic (how point is restored)
+;;   - Narrowing or read-only handling
+;;   - Overlay management for markers
+;;   - Edge cases with empty/large buffers
+;;
+;; WHY UNIT TESTS:
+;;
+;; Buffer manipulation is complex (many edge cases) and needs careful
+;; testing to avoid user-visible issues like lost point position.
+;; These unit tests verify core behavior in isolation.
+;;
+;; See doc/TESTING-UNIT-TESTS.md for patterns and utilities.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'sly-common "lib/sly-common")
+(require 'sly-unit-tests "lib/sly-unit-tests")
+
+;;;; Tests for sly--call-refreshing
+;;;;
+(ert-deftest sly-common-unit--call-refreshing-clears-buffer ()
+  "Test `sly--call-refreshing' clears buffer content."
+  (with-temp-buffer
+    (insert "Initial content")
+    (sly--call-refreshing (current-buffer) nil nil nil nil
+                          (lambda () (insert "New content")))
+    (should (equal "New content" (buffer-string)))))
+
+(ert-deftest sly-common-unit--call-refreshing-dont-erase ()
+  "Test `sly--call-refreshing' with DONT-ERASE flag."
+  (with-temp-buffer
+    (insert "Existing content\n")
+    (sly--call-refreshing (current-buffer) nil t nil nil
+                          (lambda () (insert "Added content")))
+    (should (equal "Existing content\nAdded content" (buffer-string)))))
+
+(ert-deftest sly-common-unit--call-refreshing-recover-point ()
+  "Test `sly--call-refreshing' recovers point position."
+  (with-temp-buffer
+    (insert "Line 1\nLine 2\nLine 3\n")
+    (goto-char 10) ; Middle of buffer
+    (let ((original-point (point)))
+      (sly--call-refreshing (current-buffer) nil t t nil
+                            (lambda () (insert "Extra\n")))
+      ;; Point should be restored to original position
+      (should (= original-point (point))))))
+
+(ert-deftest sly-common-unit--call-refreshing-no-recover-point ()
+  "Test `sly--call-refreshing' without point recovery."
+  (with-temp-buffer
+    (insert "Content")
+    (goto-char (point-min))
+    (sly--call-refreshing (current-buffer) nil nil nil nil
+                          (lambda ()
+                            (insert "New content")
+                            (goto-char (point-max))))
+    ;; Point should not be at beginning
+    (should (= (point) (point-max)))))
+
+(ert-deftest sly-common-unit--call-refreshing-with-overlay ()
+  "Test `sly--call-refreshing' restricted to overlay region."
+  ;; WHY THIS IS COMPLEX:
+  ;; When refreshing a buffer region (instead of whole buffer), we pass an
+  ;; overlay that marks the region to refresh. The function must:
+  ;;   1. Clear only content in the overlay region (8-15)
+  ;;   2. Execute the body (inserts replacement text)
+  ;;   3. Leave content outside overlay untouched
+  ;;
+  ;; Setup: "Before\nMiddle\nAfter\n"
+  ;;        12345678 15  23   28
+  ;; Overlay spans 8-15, covering "Middle\n"
+  (with-temp-buffer
+    (insert "Before\nMiddle\nAfter\n")
+    (let ((ov (make-overlay 8 15))) ; ← Marks "Middle\n" region
+      (unwind-protect
+          (progn
+            (sly--call-refreshing (current-buffer) ov nil nil nil
+                                  (lambda () (insert "REPLACED")))
+            ;; Verify only overlay region was affected
+            (should (string-match-p "Before" (buffer-string)))  ; ← outside overlay
+            (should (string-match-p "REPLACED" (buffer-string)))  ; ← replacement inserted
+            (should (string-match-p "After" (buffer-string)))  ; ← outside overlay
+            (should-not (string-match-p "Middle" (buffer-string)))  ; ← cleared by refresh
+        (delete-overlay ov)))))
+
+(ert-deftest sly-common-unit--call-refreshing-returns-buffer ()
+  "Test `sly--call-refreshing' returns the buffer."
+  (with-temp-buffer
+    (let ((result (sly--call-refreshing (current-buffer) nil nil nil nil
+                                        (lambda () (insert "test")))))
+      (should (eq result (current-buffer))))))
+
+(ert-deftest sly-common-unit--call-refreshing-inhibit-read-only ()
+  "Test `sly--call-refreshing' works with read-only buffers."
+  (with-temp-buffer
+    (insert "Read-only content")
+    (setq buffer-read-only t)
+    ;; Should not error even though buffer is read-only
+    (should-not
+     (condition-case nil
+         (progn
+           (sly--call-refreshing (current-buffer) nil nil nil nil
+                                 (lambda () (insert "Modified")))
+           nil)
+       (error t)))))
+
+;;;; Tests for sly-refreshing macro
+;;;;
+(ert-deftest sly-common-unit--refreshing-macro-basic ()
+  "Test `sly-refreshing' macro basic usage."
+  (with-temp-buffer
+    (insert "Old content")
+    (sly-refreshing ()
+      (insert "New content"))
+    (should (equal "New content" (buffer-string)))))
+
+(ert-deftest sly-common-unit--refreshing-macro-dont-erase ()
+  "Test `sly-refreshing' macro with :dont-erase."
+  (with-temp-buffer
+    (insert "Existing\n")
+    (sly-refreshing (:dont-erase t)
+      (insert "Appended"))
+    (should (equal "Existing\nAppended" (buffer-string)))))
+
+(ert-deftest sly-common-unit--refreshing-macro-overlay ()
+  "Test `sly-refreshing' macro with :overlay."
+  (with-temp-buffer
+    (insert "AAA\nBBB\nCCC\n")
+    (let ((ov (make-overlay 5 9))) ; "BBB\n"
+      (unwind-protect
+          (progn
+            (sly-refreshing (:overlay ov)
+              (insert "XXX"))
+            (should (string-match-p "AAA" (buffer-string)))
+            (should (string-match-p "XXX" (buffer-string)))
+            (should (string-match-p "CCC" (buffer-string)))
+            (should-not (string-match-p "BBB" (buffer-string))))
+        (delete-overlay ov)))))
+
+(ert-deftest sly-common-unit--refreshing-macro-recover-point ()
+  "Test `sly-refreshing' macro with :recover-point-p."
+  (with-temp-buffer
+    (insert "Line 1\nLine 2\n")
+    (goto-char 5)
+    (let ((saved-point (point)))
+      (sly-refreshing (:dont-erase t :recover-point-p t)
+        (goto-char (point-max))
+        (insert "Line 3\n"))
+      (should (= saved-point (point))))))
+
+(ert-deftest sly-common-unit--refreshing-macro-no-recover-point ()
+  "Test `sly-refreshing' macro with :recover-point-p nil."
+  (with-temp-buffer
+    (insert "Content")
+    (goto-char (point-min))
+    (sly-refreshing (:recover-point-p nil)
+      (insert "New")
+      (goto-char (point-max)))
+    (should (= (point) (point-max)))))
+
+(ert-deftest sly-common-unit--refreshing-macro-in-other-buffer ()
+  "Test `sly-refreshing' macro with :buffer parameter."
+  (let ((buf1 (generate-new-buffer " *test1*"))
+        (buf2 (generate-new-buffer " *test2*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf1
+            (insert "Buffer 1 content"))
+          (with-current-buffer buf2
+            (insert "Buffer 2 content"))
+          ;; Execute in buf2's context but refresh buf1
+          (with-current-buffer buf2
+            (sly-refreshing (:buffer buf1)
+              (insert "Modified")))
+          ;; buf1 should be modified, buf2 unchanged
+          (with-current-buffer buf1
+            (should (equal "Modified" (buffer-string))))
+          (with-current-buffer buf2
+            (should (equal "Buffer 2 content" (buffer-string)))))
+      (kill-buffer buf1)
+      (kill-buffer buf2))))
+
+(ert-deftest sly-common-unit--refreshing-macro-multiple-forms ()
+  "Test `sly-refreshing' macro with multiple body forms."
+  (with-temp-buffer
+    (insert "Old")
+    (sly-refreshing ()
+      (insert "Line 1\n")
+      (insert "Line 2\n")
+      (insert "Line 3"))
+    (should (equal "Line 1\nLine 2\nLine 3" (buffer-string)))))
+
+(ert-deftest sly-common-unit--refreshing-macro-returns-buffer ()
+  "Test `sly-refreshing' macro returns buffer."
+  (with-temp-buffer
+    (let ((result (sly-refreshing ()
+                    (insert "test"))))
+      (should (eq result (current-buffer))))))
+
+;;;; Edge cases
+;;;;
+(ert-deftest sly-common-unit--refreshing-empty-buffer ()
+  "Test refreshing an empty buffer."
+  (with-temp-buffer
+    (sly-refreshing ()
+      (insert "New content"))
+    (should (equal "New content" (buffer-string)))))
+
+(ert-deftest sly-common-unit--refreshing-empty-body ()
+  "Test refreshing with empty body."
+  (with-temp-buffer
+    (insert "Content")
+    (sly-refreshing ())
+    ;; Should clear buffer but not insert anything
+    (should (equal "" (buffer-string)))))
+
+(ert-deftest sly-common-unit--refreshing-narrowed-buffer ()
+  "Test refreshing works with narrowed buffer."
+  (with-temp-buffer
+    (insert "Part1\nPart2\nPart3\n")
+    (goto-char (point-min))
+    (search-forward "Part2")
+    (beginning-of-line)
+    (narrow-to-region (point) (line-end-position))
+    (sly-refreshing ()
+      (insert "Replaced"))
+    (widen)
+    ;; Only the narrowed region should be replaced
+    (should (string-match-p "Part1" (buffer-string)))
+    (should (string-match-p "Replaced" (buffer-string)))
+    (should (string-match-p "Part3" (buffer-string)))))
+
+(provide 'sly-common-unit-tests)
+;;; sly-common-unit-tests.el ends here

--- a/test/sly-completion-unit-tests.el
+++ b/test/sly-completion-unit-tests.el
@@ -1,0 +1,259 @@
+;;; sly-completion-unit-tests.el --- Unit tests for sly-completion.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 SLY Contributors
+
+;;; Commentary:
+
+;; Unit tests for the completion utilities in lib/sly-completion.el.
+;; Tests cover pure Elisp functionality that doesn't require a Lisp connection.
+;;
+;; WHAT IS TESTED:
+;;
+;; This module tests SLY's completion system—how symbols are suggested,
+;; annotated (labeled with type/category info), cached, and filtered.
+;; Completion bridges Emacs' completion UI with Lisp backend responses.
+;;
+;; KEY FUNCTIONS TESTED:
+;;
+;; sly-completion-at-point: Main completion function
+;;   - Provides candidates to Emacs when user presses TAB
+;;   - Suppresses completion in strings and comments
+;;   - Handles caching for performance
+;;   - Formats completions with metadata from Lisp
+;;
+;; sly-completion-annotation: Shows metadata for each completion
+;;   - Displays classification (function, variable, macro, etc.)
+;;   - Shows scores or relevance information
+;;   - Properly formats and truncates for display
+;;
+;; WHAT IS COVERED:
+;;
+;; String/Comment Detection:
+;;   - Suppress completion inside string literals
+;;   - Suppress completion in line comments
+;;   - Allow completion in code
+;;
+;; Annotation Formatting:
+;;   - Show classification (fn, var, macro, class, etc.)
+;;   - Show relevance scores
+;;   - Format annotations for display width
+;;   - Combine multiple metadata fields
+;;
+;; Caching:
+;;   - Cache completion results
+;;   - Invalidate cache on edits
+;;   - Verify calls to Lisp (using mock-eval)
+;;
+;; Completion Metadata:
+;;   - Extract and store classification
+;;   - Extract and store relevance scores
+;;   - Handle missing metadata gracefully
+;;
+;; WHEN TO ADD TESTS:
+;;
+;; Add tests when modifying:
+;;   - Context detection (string/comment suppression)
+;;   - Annotation display format
+;;   - Caching strategy or invalidation
+;;   - Metadata handling from Lisp
+;;   - Completion filtering or sorting
+;;
+;; WHY UNIT TESTS:
+;;
+;; Completion logic is pure Elisp (doesn't need full SLY) and must be
+;; fast (users expect instant feedback). Unit tests verify behavior
+;; without waiting for Lisp server startup.
+;;
+;; See doc/TESTING-UNIT-TESTS.md for patterns and utilities.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'sly-completion "lib/sly-completion")
+(require 'sly-unit-tests "lib/sly-unit-tests")
+(require 'sly-test-mocks "test/sly-test-mocks")
+
+;;;; Tests for sly-completion-annotation
+;;;;
+(ert-deftest sly-completion-unit--annotation-empty ()
+  "Test `sly-completion-annotation' with no properties."
+  (let ((completion "foo"))
+    (should (equal "" (sly-completion-annotation completion)))))
+
+(ert-deftest sly-completion-unit--annotation-classification-only ()
+  "Test `sly-completion-annotation' with classification."
+  (let ((completion (propertize "foo" 'sly--classification "fn")))
+    (should (equal "fn" (sly-completion-annotation completion)))))
+
+(ert-deftest sly-completion-unit--annotation-score-only ()
+  "Test `sly-completion-annotation' with score."
+  (let ((completion (propertize "foo" 'sly--score 0.95)))
+    (should (string-match-p "95\\." (sly-completion-annotation completion)))))
+
+(ert-deftest sly-completion-unit--annotation-both ()
+  "Test `sly-completion-annotation' with classification and score."
+  (let ((completion (propertize "foo"
+                                'sly--classification "macro"
+                                'sly--score 0.85)))
+    (let ((annotation (sly-completion-annotation completion)))
+      (should (string-match-p "macro" annotation))
+      (should (string-match-p "85\\." annotation)))))
+
+;;;; Tests for sly--completion-inside-string-or-comment-p
+;;;;
+(ert-deftest sly-completion-unit--inside-string-or-comment-in-string ()
+  "Test `sly--completion-inside-string-or-comment-p' in string."
+  (sly-unit-with-temp-lisp-buffer "(print \"hello world\")"
+    (search-forward "hello")
+    (should (sly--completion-inside-string-or-comment-p))))
+
+(ert-deftest sly-completion-unit--inside-string-or-comment-in-comment ()
+  "Test `sly--completion-inside-string-or-comment-p' in comment."
+  (sly-unit-with-temp-lisp-buffer "(foo) ; comment here"
+    (search-forward "comment")
+    (should (sly--completion-inside-string-or-comment-p))))
+
+(ert-deftest sly-completion-unit--inside-string-or-comment-in-code ()
+  "Test `sly--completion-inside-string-or-comment-p' in code."
+  (sly-unit-with-temp-lisp-buffer "(defun foo () nil)"
+    (search-forward "foo")
+    (should-not (sly--completion-inside-string-or-comment-p))))
+
+;;;; Tests for sly--completion-function-wrapper
+;;;;
+(ert-deftest sly-completion-unit--function-wrapper-all-completions ()
+  "Test completion wrapper returns all completions."
+  (let* ((completions '("foo" "foobar" "foobaz"))
+         (fn (lambda (_pattern) (list completions nil)))
+         (wrapper (sly--completion-function-wrapper fn)))
+    (should (equal completions (funcall wrapper "f" nil t)))))
+
+(ert-deftest sly-completion-unit--function-wrapper-try-completion ()
+  "Test completion wrapper try-completion."
+  (let* ((completions '("foobar" "foobaz"))
+         (fn (lambda (_pattern) (list completions nil)))
+         (wrapper (sly--completion-function-wrapper fn)))
+    ;; try-completion should return common prefix
+    (should (equal "fooba" (funcall wrapper "foo" nil nil)))))
+
+(ert-deftest sly-completion-unit--function-wrapper-try-completion-unique ()
+  "Test completion wrapper try-completion with unique match."
+  (let* ((completions '("foobar"))
+         (fn (lambda (_pattern) (list completions nil)))
+         (wrapper (sly--completion-function-wrapper fn)))
+    ;; try-completion should return t for unique match
+    (should (eq t (funcall wrapper "foobar" nil nil)))))
+
+(ert-deftest sly-completion-unit--function-wrapper-metadata ()
+  "Test completion wrapper returns proper metadata."
+  (let* ((fn (lambda (_pattern) (list '("foo") nil)))
+         (wrapper (sly--completion-function-wrapper fn)))
+    (let ((metadata (funcall wrapper "f" nil 'metadata)))
+      (should (eq 'metadata (car metadata)))
+      (should (eq 'sly-completion (cdr (assq 'category (cdr metadata))))))))
+
+(ert-deftest sly-completion-unit--function-wrapper-caching ()
+  "Test completion wrapper caches results."
+  (let* ((call-count 0)
+         (fn (lambda (_pattern)
+               (cl-incf call-count)
+               (list '("foo" "bar") nil)))
+         (wrapper (sly--completion-function-wrapper fn)))
+    ;; First call
+    (funcall wrapper "test" nil t)
+    (should (= 1 call-count))
+    ;; Second call with same pattern should use cache
+    (funcall wrapper "test" nil t)
+    (should (= 1 call-count))
+    ;; Different pattern should call function again
+    (funcall wrapper "other" nil t)
+    (should (= 2 call-count))))
+
+(ert-deftest sly-completion-unit--function-wrapper-sly-identify ()
+  "Test completion wrapper responds to sly--identify."
+  (let* ((fn (lambda (_pattern) (list '("foo") nil)))
+         (wrapper (sly--completion-function-wrapper fn)))
+    (should (eq t (funcall wrapper nil nil 'sly--identify)))))
+
+;;;; Tests for sly--external-tryc
+;;;;
+(ert-deftest sly-completion-unit--external-tryc-unique ()
+  "Test `sly--external-tryc' with unique completion."
+  (let ((table (lambda (_s _p _a) '("foobar"))))
+    ;; When pattern equals the sole completion, return t
+    (should (eq t (sly--external-tryc "foobar" table nil 6)))))
+
+(ert-deftest sly-completion-unit--external-tryc-partial ()
+  "Test `sly--external-tryc' with partial match."
+  (let ((table (lambda (_s _p _a) '("foobar"))))
+    ;; When pattern doesn't equal completion, return (completion . length)
+    (let ((result (sly--external-tryc "foo" table nil 3)))
+      (should (consp result))
+      (should (equal "foobar" (car result))))))
+
+(ert-deftest sly-completion-unit--external-tryc-multiple ()
+  "Test `sly--external-tryc' with multiple matches."
+  (let ((table (lambda (_s _p _a) '("foobar" "foobaz"))))
+    ;; With multiple matches, return (pattern . point)
+    (let ((result (sly--external-tryc "foo" table nil 3)))
+      (should (consp result))
+      (should (equal "foo" (car result)))
+      (should (= 3 (cdr result))))))
+
+;;;; Tests for sly--external-allc
+;;;;
+(ert-deftest sly-completion-unit--external-allc ()
+  "Test `sly--external-allc' returns all completions."
+  (let ((completions '("foo" "foobar" "foobaz"))
+        (table (lambda (_s _p _a) '("foo" "foobar" "foobaz"))))
+    (should (equal completions (sly--external-allc "f" table nil 1)))))
+
+;;;; Tests for completion buffer filling (simplified)
+;;;;
+;; Note: These functions require full SLY initialization and are better tested
+;; in integration tests. Unit tests focus on the annotation and property logic.
+
+(ert-deftest sly-completion-unit--annotation-properties ()
+  "Test completion annotations are correctly formatted."
+  (let ((completion (propertize "test-fn"
+                                'sly--classification "macro"
+                                'sly--score 0.92)))
+    (let ((annotation (sly-completion-annotation completion)))
+      (should (string-match-p "macro" annotation))
+      (should (string-match-p "92" annotation)))))
+
+;;;; Tests for flex completion chunks highlighting
+;;;;
+(ert-deftest sly-completion-unit--flex-chunks-property ()
+  "Test flex completion chunks are stored as property."
+  (let ((completion (propertize "multiple-value-bind"
+                                'sly-completion-chunks
+                                '((0 . 1) (9 . 10) (15 . 16)))))
+    (should (equal '((0 . 1) (9 . 10) (15 . 16))
+                   (get-text-property 0 'sly-completion-chunks completion)))))
+
+;;;; Integration test with mock eval
+;;;;
+(ert-deftest sly-completion-unit--simple-completions-with-mock ()
+  "Test `sly-simple-completions' with mocked eval."
+  ;; WHY THIS IS COMPLEX:
+  ;; The underlying function calls (slynk-completion:simple-completions "pri" 'CL-USER)
+  ;; with a quoted package name. The mock must match this exact form, including
+  ;; the quote. Notice '"CL-USER" (a quoted string) not just "CL-USER".
+  ;;
+  ;; The response is a list: ((COMPLETIONS...) PREFIX-USED)
+  ;; where PREFIX-USED helps with filtering.
+  (sly-test-with-mock-eval
+      (((slynk-completion:simple-completions "pri" '"CL-USER")  ; ← package is quoted!
+        . (("print" "princ" "prin1") "pri")))  ; ← response: (completions prefix)
+    ;; Call the function being tested
+    (let ((result (sly-simple-completions "pri")))
+      ;; Verify it returns a 2-element list
+      (should (listp result))
+      (should (= 2 (length result)))
+      ;; Verify one of the expected completions is present
+      (should (member "print" (car result))))))
+
+(provide 'sly-completion-unit-tests)
+;;; sly-completion-unit-tests.el ends here

--- a/test/sly-hyperspec-unit-tests.el
+++ b/test/sly-hyperspec-unit-tests.el
@@ -1,0 +1,233 @@
+;;; sly-hyperspec-unit-tests.el --- Unit tests for hyperspec.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 SLY Contributors
+
+;;; Commentary:
+
+;; Unit tests for the HyperSpec utilities in lib/hyperspec.el.
+;; Tests cover pure Elisp functionality for symbol name parsing and lookup.
+;;
+;; WHAT IS TESTED:
+;;
+;; This module tests SLY's integration with the Common Lisp HyperSpec—
+;; the standard documentation for Common Lisp.  HyperSpec support lets
+;; users press C-c C-d to view documentation for a symbol without leaving
+;; Emacs.  This requires parsing symbol names and looking them up in a
+;; database.
+;;
+;; KEY FUNCTIONS TESTED:
+;;
+;; common-lisp-hyperspec--strip-cl-package: Remove package prefixes
+;;   - Strips CL:: (internal symbol access)
+;;   - Strips CL: (external symbol access)
+;;   - Strips COMMON-LISP:: and COMMON-LISP:
+;;   - Handles lowercase variants (cl::, common-lisp::)
+;;
+;; common-lisp-hyperspec-lookup: Find symbol in HyperSpec database
+;;   - Insert symbols into hash table
+;;   - Query for symbol URL
+;;   - Proper case handling
+;;
+;; WHAT IS COVERED:
+;;
+;; Package Prefix Stripping:
+;;   - CL:: internal access (most common)
+;;   - CL: external access (less common)
+;;   - COMMON-LISP:: full package name
+;;   - COMMON-LISP: full package with external
+;;   - Case variations (lowercase)
+;;   - No prefix (already clean)
+;;
+;; Symbol Handling:
+;;   - Deduplication (same symbol shouldn't appear twice)
+;;   - Case-insensitive lookup (Common Lisp symbols are case-insensitive)
+;;   - Special characters in symbols (#, +, -, etc.)
+;;   - Symbols with unusual names
+;;
+;; Database Operations:
+;;   - Insert symbol -> URL mappings
+;;   - Query for symbols
+;;   - Return URLs
+;;
+;; WHEN TO ADD TESTS:
+;;
+;; Add tests when modifying:
+;;   - Package prefix handling
+;;   - Symbol deduplication logic
+;;   - Case sensitivity handling
+;;   - Symbol insertion/lookup
+;;   - Database structure
+;;
+;; WHY UNIT TESTS:
+;;
+;; HyperSpec lookups must be fast (user presses a key, they expect
+;; instant response) and accurate (wrong symbol leads to frustration).
+;; Unit tests verify parsing and lookup work correctly before hitting
+;; the network or accessing the HyperSpec database.
+;;
+;; See doc/TESTING-UNIT-TESTS.md for patterns and utilities.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'hyperspec "lib/hyperspec")
+(require 'sly-unit-tests "lib/sly-unit-tests")
+
+;;;; Tests for common-lisp-hyperspec--strip-cl-package
+;;;;
+(ert-deftest sly-hyperspec-unit--strip-cl-package-with-cl ()
+  "Test stripping CL:: prefix."
+  (should (equal "defun"
+                 (common-lisp-hyperspec--strip-cl-package "cl::defun"))))
+
+(ert-deftest sly-hyperspec-unit--strip-cl-package-with-cl-single-colon ()
+  "Test stripping CL: prefix (external symbol)."
+  (should (equal "defun"
+                 (common-lisp-hyperspec--strip-cl-package "cl:defun"))))
+
+(ert-deftest sly-hyperspec-unit--strip-cl-package-with-common-lisp ()
+  "Test stripping COMMON-LISP:: prefix."
+  (should (equal "car"
+                 (common-lisp-hyperspec--strip-cl-package "common-lisp::car"))))
+
+(ert-deftest sly-hyperspec-unit--strip-cl-package-with-common-lisp-single-colon ()
+  "Test stripping COMMON-LISP: prefix."
+  (should (equal "car"
+                 (common-lisp-hyperspec--strip-cl-package "common-lisp:car"))))
+
+(ert-deftest sly-hyperspec-unit--strip-cl-package-case-insensitive ()
+  "Test stripping is case-insensitive."
+  (should (equal "list"
+                 (common-lisp-hyperspec--strip-cl-package "CL::list")))
+  (should (equal "cons"
+                 (common-lisp-hyperspec--strip-cl-package "Common-Lisp::cons"))))
+
+(ert-deftest sly-hyperspec-unit--strip-cl-package-other-package ()
+  "Test that non-CL packages are not stripped."
+  (should (equal "foo::bar"
+                 (common-lisp-hyperspec--strip-cl-package "foo::bar")))
+  (should (equal "my-package:symbol"
+                 (common-lisp-hyperspec--strip-cl-package "my-package:symbol"))))
+
+(ert-deftest sly-hyperspec-unit--strip-cl-package-no-package ()
+  "Test symbol with no package prefix."
+  (should (equal "defun"
+                 (common-lisp-hyperspec--strip-cl-package "defun")))
+  (should (equal "my-function"
+                 (common-lisp-hyperspec--strip-cl-package "my-function"))))
+
+(ert-deftest sly-hyperspec-unit--strip-cl-package-empty ()
+  "Test with empty string."
+  (should (equal ""
+                 (common-lisp-hyperspec--strip-cl-package ""))))
+
+(ert-deftest sly-hyperspec-unit--strip-cl-package-keyword ()
+  "Test with keyword (single colon prefix)."
+  ;; Keywords like :foo should not match the pattern (no package before :)
+  (should (equal ":keyword"
+                 (common-lisp-hyperspec--strip-cl-package ":keyword"))))
+
+;;;; Tests for common-lisp-hyperspec--find and common-lisp-hyperspec--insert
+;;;;
+(ert-deftest sly-hyperspec-unit--insert-and-find ()
+  "Test inserting and finding a symbol."
+  (let ((common-lisp-hyperspec--symbols (make-hash-table :test 'equal)))
+    (common-lisp-hyperspec--insert "defun" "m_defun.htm")
+    (should (equal '("m_defun.htm")
+                   (common-lisp-hyperspec--find "defun")))))
+
+(ert-deftest sly-hyperspec-unit--insert-multiple-urls ()
+  "Test inserting multiple URLs for the same symbol."
+  (let ((common-lisp-hyperspec--symbols (make-hash-table :test 'equal)))
+    (common-lisp-hyperspec--insert "list" "f_list_.htm")
+    (common-lisp-hyperspec--insert "list" "a_list.htm")
+    (let ((urls (common-lisp-hyperspec--find "list")))
+      (should (= 2 (length urls)))
+      (should (member "f_list_.htm" urls))
+      (should (member "a_list.htm" urls)))))
+
+(ert-deftest sly-hyperspec-unit--insert-duplicate-url ()
+  "Test inserting duplicate URL doesn't create duplicates."
+  (let ((common-lisp-hyperspec--symbols (make-hash-table :test 'equal)))
+    (common-lisp-hyperspec--insert "cons" "f_cons.htm")
+    (common-lisp-hyperspec--insert "cons" "f_cons.htm")
+    (common-lisp-hyperspec--insert "cons" "f_cons.htm")
+    ;; Should only have one entry due to :test #'equal in cl-pushnew
+    (should (equal '("f_cons.htm")
+                   (common-lisp-hyperspec--find "cons")))))
+
+(ert-deftest sly-hyperspec-unit--find-nonexistent ()
+  "Test finding a symbol that doesn't exist."
+  (let ((common-lisp-hyperspec--symbols (make-hash-table :test 'equal)))
+    (should (null (common-lisp-hyperspec--find "nonexistent-symbol")))))
+
+(ert-deftest sly-hyperspec-unit--find-case-sensitive ()
+  "Test that symbol lookup is case-sensitive."
+  (let ((common-lisp-hyperspec--symbols (make-hash-table :test 'equal)))
+    (common-lisp-hyperspec--insert "defun" "m_defun.htm")
+    ;; Hash table uses 'equal which is case-sensitive for strings
+    (should (common-lisp-hyperspec--find "defun"))
+    (should-not (common-lisp-hyperspec--find "DEFUN"))
+    (should-not (common-lisp-hyperspec--find "Defun"))))
+
+(ert-deftest sly-hyperspec-unit--insert-empty-symbol ()
+  "Test inserting empty symbol name."
+  (let ((common-lisp-hyperspec--symbols (make-hash-table :test 'equal)))
+    (common-lisp-hyperspec--insert "" "empty.htm")
+    (should (equal '("empty.htm")
+                   (common-lisp-hyperspec--find "")))))
+
+(ert-deftest sly-hyperspec-unit--insert-special-characters ()
+  "Test inserting symbols with special characters."
+  (let ((common-lisp-hyperspec--symbols (make-hash-table :test 'equal)))
+    (common-lisp-hyperspec--insert "*standard-output*" "v_debug_.htm")
+    (common-lisp-hyperspec--insert "1+" "f_1pl_1_.htm")
+    (common-lisp-hyperspec--insert "++" "v__pl_pl.htm")
+    (should (common-lisp-hyperspec--find "*standard-output*"))
+    (should (common-lisp-hyperspec--find "1+"))
+    (should (common-lisp-hyperspec--find "++"))))
+
+;;;; Tests for symbol table data structure
+;;;;
+(ert-deftest sly-hyperspec-unit--symbols-hash-table-exists ()
+  "Test that `common-lisp-hyperspec--symbols' is a hash table."
+  (should (hash-table-p common-lisp-hyperspec--symbols)))
+
+(ert-deftest sly-hyperspec-unit--symbols-hash-table-test ()
+  "Test that hash table uses 'equal for comparison."
+  (should (eq 'equal (hash-table-test common-lisp-hyperspec--symbols))))
+
+(ert-deftest sly-hyperspec-unit--symbols-preloaded ()
+  "Test that some standard CL symbols are preloaded."
+  ;; The hyperspec.el file preloads many symbols at load time
+  ;; Test a few common ones
+  (should (common-lisp-hyperspec--find "defun"))
+  (should (common-lisp-hyperspec--find "let"))
+  (should (common-lisp-hyperspec--find "if")))
+
+;;;; Tests for integration of strip and find
+;;;;
+(ert-deftest sly-hyperspec-unit--strip-and-find-workflow ()
+  "Test typical workflow of stripping package and finding symbol."
+  ;; This simulates what happens when user looks up CL::DEFUN
+  (let* ((user-input "CL::DEFUN")
+         (stripped (downcase
+                    (common-lisp-hyperspec--strip-cl-package user-input)))
+         (result (common-lisp-hyperspec--find stripped)))
+    (should (equal "defun" stripped))
+    (should result)
+    (should (listp result))))
+
+(ert-deftest sly-hyperspec-unit--strip-preserves-non-cl-packages ()
+  "Test that non-CL packages are preserved in lookup."
+  (let ((common-lisp-hyperspec--symbols (make-hash-table :test 'equal)))
+    ;; Insert with full package name
+    (common-lisp-hyperspec--insert "foo::bar" "custom.htm")
+    ;; Strip should preserve it
+    (let ((stripped (common-lisp-hyperspec--strip-cl-package "foo::bar")))
+      (should (equal "foo::bar" stripped))
+      (should (common-lisp-hyperspec--find stripped)))))
+
+(provide 'sly-hyperspec-unit-tests)
+;;; sly-hyperspec-unit-tests.el ends here

--- a/test/sly-messages-unit-tests.el
+++ b/test/sly-messages-unit-tests.el
@@ -1,0 +1,306 @@
+;;; sly-messages-unit-tests.el --- Unit tests for sly-messages.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 SLY Contributors
+
+;;; Commentary:
+
+;; Unit tests for the messaging utilities in lib/sly-messages.el.
+;; Tests cover pure Elisp functionality that doesn't require timers or user interaction.
+;;
+;; WHAT IS TESTED:
+;;
+;; This module tests SLY's system for communicating with the user—messages,
+;; warnings, errors, and visual feedback.  Good messaging is critical for
+;; user experience: users need clear feedback about what's happening and
+;; what went wrong, without overwhelming them with noise.
+;;
+;; KEY FUNCTIONS TESTED:
+;;
+;; sly-message: Informational messages
+;;   - Display in echo area and message buffer
+;;   - Prefix with [sly] tag
+;;   - Truncate long messages
+;;   - Oneliners (first line only)
+;;
+;; sly-warning: Warning messages
+;;   - Styled as warnings
+;;   - Prefix appropriately
+;;   - Different from info (user should notice)
+;;
+;; sly-error: Error messages
+;;   - Style indicates error occurred
+;;   - Prefix appropriately
+;;   - Clear indication of problem
+;;
+;; sly-user-error: Errors caused by user action (not SLY bug)
+;;   - Styled as user error (not internal error)
+;;   - Clear and actionable message
+;;
+;; sly-flash-region: Visual feedback
+;;   - Highlight a region temporarily
+;;   - Provides visual confirmation
+;;
+;; WHAT IS COVERED:
+;;
+;; Message Formatting:
+;;   - Prefix messages with [sly]
+;;   - Oneliners (truncate at newline)
+;;   - Long message truncation
+;;   - Empty message handling
+;;
+;; Message Levels:
+;;   - Info/message level (normal)
+;;   - Warning level (user should notice)
+;;   - Error level (something failed)
+;;   - User-error (user caused the problem)
+;;
+;; Prompt Formatting:
+;;   - Formatting prompts with [sly] prefix
+;;   - Handling newlines and whitespace
+;;   - Prompt display in minibuffer
+;;
+;; Visual Feedback:
+;;   - Flashing regions for highlights
+;;   - Temporary highlighting
+;;   - Face application
+;;
+;; WHEN TO ADD TESTS:
+;;
+;; Add tests when modifying:
+;;   - Message formatting or prefixing
+;;   - Message level distinctions
+;;   - Truncation behavior
+;;   - Visual feedback (flashing)
+;;   - Prompt formatting
+;;
+;; WHY UNIT TESTS:
+;;
+;; Message formatting must be consistent (users rely on visual patterns
+;; to understand messages quickly) and robust (handle edge cases like
+;; empty messages, very long messages, special characters). Unit tests
+;; verify formatting works correctly.
+;;
+;; See doc/TESTING-UNIT-TESTS.md for patterns and utilities.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'sly-messages "lib/sly-messages")
+(require 'sly-unit-tests "lib/sly-unit-tests")
+
+;;;; Tests for sly-oneliner
+;;;;
+(ert-deftest sly-messages-unit--oneliner-short-string ()
+  "Test `sly-oneliner' with string shorter than window width."
+  (let ((input "Short message"))
+    (should (equal input (sly-oneliner input)))))
+
+(ert-deftest sly-messages-unit--oneliner-with-newline ()
+  "Test `sly-oneliner' truncates at newline."
+  (let ((input "First line\nSecond line\nThird line"))
+    (should (equal "First line" (sly-oneliner input)))))
+
+(ert-deftest sly-messages-unit--oneliner-empty-string ()
+  "Test `sly-oneliner' with empty string."
+  (should (equal "" (sly-oneliner ""))))
+
+(ert-deftest sly-messages-unit--oneliner-single-newline ()
+  "Test `sly-oneliner' with string that's just a newline."
+  (should (equal "" (sly-oneliner "\n"))))
+
+(ert-deftest sly-messages-unit--oneliner-multiple-newlines ()
+  "Test `sly-oneliner' with multiple consecutive newlines."
+  (should (equal "" (sly-oneliner "\n\n\n"))))
+
+(ert-deftest sly-messages-unit--oneliner-newline-at-end ()
+  "Test `sly-oneliner' with newline at end."
+  (let ((input "Message with trailing newline\n"))
+    (should (equal "Message with trailing newline" (sly-oneliner input)))))
+
+(ert-deftest sly-messages-unit--oneliner-very-long-line ()
+  "Test `sly-oneliner' truncates very long line to window width."
+  (let* ((window-width (window-width (minibuffer-window)))
+         (long-string (make-string (* 2 window-width) ?x))
+         (result (sly-oneliner long-string)))
+    ;; Should be truncated to less than window width
+    (should (< (length result) window-width))
+    ;; Should be exactly window-width - 1
+    (should (= (length result) (1- window-width)))))
+
+;;;; Tests for sly-message
+;;;;
+(ert-deftest sly-messages-unit--message-format ()
+  "Test `sly-message' adds [sly] prefix."
+  (let ((sly--last-message nil))
+    (sly-unit-with-mock ((message (lambda (fmt &rest args)
+                                     (apply #'format fmt args))))
+      (sly-message "Test message")
+      (should (equal "[sly] Test message" sly--last-message)))))
+
+(ert-deftest sly-messages-unit--message-with-args ()
+  "Test `sly-message' with format arguments."
+  (let ((sly--last-message nil))
+    (sly-unit-with-mock ((message (lambda (fmt &rest args)
+                                     (apply #'format fmt args))))
+      (sly-message "Value: %s, Number: %d" "foo" 42)
+      (should (equal "[sly] Value: foo, Number: 42" sly--last-message)))))
+
+(ert-deftest sly-messages-unit--message-updates-last-message ()
+  "Test `sly-message' updates `sly--last-message'."
+  (let ((sly--last-message nil))
+    (sly-unit-with-mock ((message (lambda (fmt &rest args)
+                                     (apply #'format fmt args))))
+      (sly-message "First message")
+      (should (equal "[sly] First message" sly--last-message))
+      (sly-message "Second message")
+      (should (equal "[sly] Second message" sly--last-message)))))
+
+;;;; Tests for sly--message-clear-last-message
+;;;;
+(ert-deftest sly-messages-unit--clear-last-message ()
+  "Test `sly--message-clear-last-message' clears state."
+  (let ((sly--last-message "[sly] Some message"))
+    (sly--message-clear-last-message)
+    (should (null sly--last-message))))
+
+;;;; Tests for sly-error
+;;;;
+(ert-deftest sly-messages-unit--error-format ()
+  "Test `sly-error' adds [sly] prefix to error."
+  (should-error (sly-error "Something went wrong")
+                :type 'error)
+  (condition-case err
+      (sly-error "Error: %s" "bad input")
+    (error
+     (should (string-match-p "\\[sly\\] Error: bad input"
+                             (error-message-string err))))))
+
+(ert-deftest sly-messages-unit--error-with-args ()
+  "Test `sly-error' with format arguments."
+  (condition-case err
+      (sly-error "Failed at step %d: %s" 3 "timeout")
+    (error
+     (should (string-match-p "\\[sly\\] Failed at step 3: timeout"
+                             (error-message-string err))))))
+
+;;;; Tests for sly-user-error
+;;;;
+(ert-deftest sly-messages-unit--user-error-format ()
+  "Test `sly-user-error' adds [sly] prefix."
+  (should-error (sly-user-error "User mistake")
+                :type 'user-error)
+  (condition-case err
+      (sly-user-error "Invalid input: %s" "foo")
+    (user-error
+     (should (string-match-p "\\[sly\\] Invalid input: foo"
+                             (error-message-string err))))))
+
+;;;; Tests for sly-warning
+;;;;
+(ert-deftest sly-messages-unit--warning-format ()
+  "Test `sly-warning' formats warning message."
+  (let ((warning-messages nil))
+    (sly-unit-with-mock ((display-warning
+                          (lambda (type message &optional level buffer-name)
+                            (push (list type message level buffer-name)
+                                  warning-messages))))
+      (sly-warning "This is a warning")
+      (should (equal 1 (length warning-messages)))
+      (let ((logged (car warning-messages)))
+        (should (equal '(sly warning) (nth 0 logged)))
+        (should (equal "This is a warning" (nth 1 logged)))))))
+
+(ert-deftest sly-messages-unit--warning-with-args ()
+  "Test `sly-warning' with format arguments."
+  (let ((warning-messages nil))
+    (sly-unit-with-mock ((display-warning
+                          (lambda (type message &optional level buffer-name)
+                            (push (list type message) warning-messages))))
+      (sly-warning "Warning at %s: %d" "point" 100)
+      (should (equal 1 (length warning-messages)))
+      (should (equal "Warning at point: 100"
+                     (nth 1 (car warning-messages)))))))
+
+;;;; Tests for sly-flash-region
+;;;;
+(ert-deftest sly-messages-unit--flash-inhibit ()
+  "Test `sly-flash-region' respects `sly-flash-inhibit'."
+  (with-temp-buffer
+    (insert "Some text to flash")
+    (let ((sly-flash-inhibit t)
+          (overlay-moved nil))
+      (sly-unit-with-mock ((move-overlay
+                            (lambda (&rest args)
+                              (setq overlay-moved t)
+                              nil)))
+        (sly-flash-region 1 10)
+        ;; When inhibited, overlay should not be moved
+        (should-not overlay-moved)))))
+
+(ert-deftest sly-messages-unit--flash-pattern-validation ()
+  "Test `sly-flash-region' validates mutually exclusive args."
+  (with-temp-buffer
+    (insert "Test text")
+    ;; Providing both PATTERN and TIMES should signal an error
+    (should-error (sly-flash-region 1 5 :pattern '(0.1) :times 2))
+    ;; Providing both PATTERN and TIMEOUT should signal an error
+    (should-error (sly-flash-region 1 5 :pattern '(0.1) :timeout 0.5))))
+
+;;;; Tests for sly-display-oneliner
+;;;;
+(ert-deftest sly-messages-unit--display-oneliner-not-in-minibuffer ()
+  "Test `sly-display-oneliner' when not in minibuffer."
+  (let ((sly--last-message nil)
+        (messages-logged nil))
+    (sly-unit-with-mock ((minibuffer-window-active-p (lambda (&rest args) nil))
+                         (message (lambda (fmt &rest args)
+                                    (push (apply #'format fmt args)
+                                          messages-logged)
+                                    nil)))
+      (sly-display-oneliner "Test message %s" "here")
+      (should sly--last-message)
+      (should (string-match-p "Test message here" sly--last-message)))))
+
+(ert-deftest sly-messages-unit--display-oneliner-in-minibuffer ()
+  "Test `sly-display-oneliner' suppressed when in minibuffer."
+  (let ((sly--last-message nil))
+    (sly-unit-with-mock ((minibuffer-window-active-p (lambda (&rest args) t))
+                         (message (lambda (fmt &rest args)
+                                    (error "Should not call message"))))
+      ;; Should not call message when in minibuffer
+      (sly-display-oneliner "Should be suppressed")
+      (should-not sly--last-message))))
+
+(ert-deftest sly-messages-unit--display-oneliner-truncates ()
+  "Test `sly-display-oneliner' truncates long messages."
+  (let ((sly--last-message nil))
+    (sly-unit-with-mock ((minibuffer-window-active-p (lambda (&rest args) nil))
+                         (message (lambda (fmt &rest args) nil)))
+      (sly-display-oneliner "First line\nSecond line\nThird line")
+      ;; Should have truncated at first newline
+      (should (string-match-p "First line" sly--last-message))
+      (should-not (string-match-p "Second line" sly--last-message)))))
+
+;;;; Tests for sly-y-or-n-p
+;;;;
+(ert-deftest sly-messages-unit--y-or-n-p-format ()
+  "Test `sly-y-or-n-p' adds [sly] prefix to prompt."
+  (let ((captured-prompt nil))
+    (sly-unit-with-mock ((y-or-n-p (lambda (prompt)
+                                      (setq captured-prompt prompt)
+                                      t)))
+      (sly-y-or-n-p "Continue?")
+      (should (equal "[sly] Continue?" captured-prompt)))))
+
+(ert-deftest sly-messages-unit--y-or-n-p-with-args ()
+  "Test `sly-y-or-n-p' with format arguments."
+  (let ((captured-prompt nil))
+    (sly-unit-with-mock ((y-or-n-p (lambda (prompt)
+                                      (setq captured-prompt prompt)
+                                      nil)))
+      (sly-y-or-n-p "Delete %d files?" 42)
+      (should (equal "[sly] Delete 42 files?" captured-prompt)))))
+
+(provide 'sly-messages-unit-tests)
+;;; sly-messages-unit-tests.el ends here

--- a/test/sly-parse-unit-tests.el
+++ b/test/sly-parse-unit-tests.el
@@ -1,0 +1,379 @@
+;;; sly-parse-unit-tests.el --- Unit tests for sly-parse.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 SLY Contributors
+
+;;; Commentary:
+
+;; Unit tests for the parsing utilities in lib/sly-parse.el.
+;; These tests do not require a live Lisp connection.
+;;
+;; WHAT IS TESTED:
+;;
+;; This module tests SLY's parsing system—how to find and understand
+;; Lisp code in buffers.  Many SLY features depend on parsing:
+;;   - "Go to definition" needs to know what symbol is at point
+;;   - Indentation needs to understand expression structure
+;;   - Flashing mismatched parens needs to find them
+;;   - Evaluation needs to know what to send to Lisp
+;;
+;; KEY FUNCTIONS TESTED:
+;;
+;; Character Syntax Detection:
+;;   - sly-compare-char-syntax: Check if char has particular syntax
+;;   - Parens, whitespace, word boundaries
+;;   - Predicate functions for character classification
+;;
+;; String and Comment Detection:
+;;   - sly-in-string-or-comment-p: Is point in literal?
+;;   - Suppress evaluation/completion in literals
+;;   - Accurate boundary detection
+;;
+;; Form Location:
+;;   - sly-parse-form-at-point: What expression is at point?
+;;   - Find beginning and end of forms
+;;   - Handle nested structures
+;;
+;; List Navigation:
+;;   - Moving between list elements
+;;   - Counting nesting depth
+;;   - Proper paren matching
+;;
+;; Pattern Matching:
+;;   - Recognize code patterns
+;;   - Distinguish different Lisp constructs
+;;   - Handle edge cases
+;;
+;; WHAT IS COVERED:
+;;
+;; Character Syntax:
+;;   - Open paren, close paren
+;;   - Whitespace characters
+;;   - Word characters (for symbols)
+;;   - Special characters
+;;
+;; Context Detection:
+;;   - Point in string? (quoted text)
+;;   - Point in line comment? (;)
+;;   - Point in block comment? (#|...|#)
+;;   - Point in quote? ('x)
+;;
+;; Form Recognition:
+;;   - S-expressions at point
+;;   - Top-level forms
+;;   - Nested lists
+;;   - Empty lists
+;;   - Quoted forms
+;;
+;; Edge Cases:
+;;   - Unbalanced parens
+;;   - Strings containing parens
+;;   - Comments with parens
+;;   - Multiple forms on one line
+;;   - Empty buffer
+;;
+;; WHEN TO ADD TESTS:
+;;
+;; Add tests when modifying:
+;;   - Character syntax detection
+;;   - String/comment boundary detection
+;;   - Form location logic
+;;   - List navigation
+;;   - Paren matching
+;;   - Pattern recognition
+;;
+;; WHY UNIT TESTS:
+;;
+;; Parsing is complex (lots of edge cases with comments, strings, nested
+;; structures) and critical for correctness (wrong parsing breaks many
+;; features). Unit tests verify parsing works correctly before relying
+;; on it in higher-level features.
+;;
+;; See doc/TESTING-UNIT-TESTS.md for patterns and utilities.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'sly-parse "lib/sly-parse")
+(require 'sly-unit-tests "lib/sly-unit-tests")
+
+;;;; Tests for sly-compare-char-syntax
+;;;;
+(ert-deftest sly-parse-unit--compare-char-syntax-open-paren ()
+  "Test `sly-compare-char-syntax' detects open paren."
+  (sly-unit-with-temp-lisp-buffer "(foo bar)"
+    (should (sly-compare-char-syntax #'char-after "("))))
+
+(ert-deftest sly-parse-unit--compare-char-syntax-close-paren ()
+  "Test `sly-compare-char-syntax' detects close paren."
+  (sly-unit-with-temp-lisp-buffer "(foo bar)"
+    (goto-char (point-max))
+    (backward-char 1)
+    (should (sly-compare-char-syntax #'char-after ")"))))
+
+(ert-deftest sly-parse-unit--compare-char-syntax-whitespace ()
+  "Test `sly-compare-char-syntax' detects whitespace."
+  (sly-unit-with-temp-lisp-buffer "(foo bar)"
+    (search-forward "foo")
+    (should (sly-compare-char-syntax #'char-after " "))))
+
+(ert-deftest sly-parse-unit--compare-char-syntax-word ()
+  "Test `sly-compare-char-syntax' detects word characters."
+  (sly-unit-with-temp-lisp-buffer "(foo bar)"
+    (forward-char 1)
+    (should (sly-compare-char-syntax #'char-after "w"))))
+
+(ert-deftest sly-parse-unit--compare-char-syntax-unescaped ()
+  "Test `sly-compare-char-syntax' with unescaped flag."
+  (sly-unit-with-temp-lisp-buffer "(foo \\(bar)"
+    (search-forward "\\")
+    ;; The ( after \ is escaped, so unescaped check should fail
+    (should-not (sly-compare-char-syntax #'char-after "(" t))))
+
+;;;; Tests for sly-pattern-path
+;;;;
+(ert-deftest sly-parse-unit--pattern-path-empty ()
+  "Test `sly-pattern-path' with empty pattern."
+  (should (equal '() (sly-pattern-path '()))))
+
+(ert-deftest sly-parse-unit--pattern-path-star ()
+  "Test `sly-pattern-path' with just *."
+  (should (equal '() (sly-pattern-path '(*)))))
+
+(ert-deftest sly-parse-unit--pattern-path-defun-star ()
+  "Test `sly-pattern-path' with (defun *)."
+  (should (equal '(defun) (sly-pattern-path '(defun *)))))
+
+(ert-deftest sly-parse-unit--pattern-path-nested ()
+  "Test `sly-pattern-path' with nested pattern ((*))."
+  (should (equal '(1) (sly-pattern-path '((*))))))
+
+(ert-deftest sly-parse-unit--pattern-path-complex ()
+  "Test `sly-pattern-path' with complex pattern."
+  ;; WHY THIS IS COMPLEX:
+  ;; Pattern matching uses nested structure to describe location in code.
+  ;; The pattern '(labels ((*))) encodes a path:
+  ;;   - labels: the symbol "labels" is at the top
+  ;;   - (*): inside a list, which contains another list with * (cursor location)
+  ;;
+  ;; The path is converted to indices:
+  ;;   - labels: symbol (kept as symbol in result)
+  ;;   - 1: first child list (index 1, counting from 0)
+  ;;   - 1: first child list of that (index 1 again)
+  ;;
+  ;; This is used to describe cursor position in nested structures like
+  ;; (labels ((slot1) (slot2))), where (* is cursor) -> '(labels 1 1)
+  ;; means: in labels form, in second sublist, in second element.
+  (should (equal '(labels 1 1) (sly-pattern-path '(labels ((*)))))))
+
+;;;; Tests for sly-arglist-specializers
+;;;;
+(ert-deftest sly-parse-unit--arglist-specializers-empty ()
+  "Test `sly-arglist-specializers' with empty arglist."
+  (should (equal '() (sly-arglist-specializers '()))))
+
+(ert-deftest sly-parse-unit--arglist-specializers-simple ()
+  "Test `sly-arglist-specializers' with unspecialized args."
+  (should (equal '(t t) (sly-arglist-specializers '(x y)))))
+
+(ert-deftest sly-parse-unit--arglist-specializers-with-types ()
+  "Test `sly-arglist-specializers' with specialized args."
+  (should (equal '(string integer)
+                 (sly-arglist-specializers '((s string) (n integer))))))
+
+(ert-deftest sly-parse-unit--arglist-specializers-mixed ()
+  "Test `sly-arglist-specializers' with mixed args."
+  (should (equal '(t string t)
+                 (sly-arglist-specializers '(x (s string) y)))))
+
+(ert-deftest sly-parse-unit--arglist-specializers-stops-at-optional ()
+  "Test `sly-arglist-specializers' stops at &optional."
+  (should (equal '(t t)
+                 (sly-arglist-specializers '(x y &optional z)))))
+
+(ert-deftest sly-parse-unit--arglist-specializers-stops-at-key ()
+  "Test `sly-arglist-specializers' stops at &key."
+  (should (equal '(t)
+                 (sly-arglist-specializers '(x &key y)))))
+
+(ert-deftest sly-parse-unit--arglist-specializers-stops-at-rest ()
+  "Test `sly-arglist-specializers' stops at &rest."
+  (should (equal '(t t)
+                 (sly-arglist-specializers '(a b &rest args)))))
+
+;;;; Tests for sly-inside-string-p
+;;;;
+(ert-deftest sly-parse-unit--inside-string-p-yes ()
+  "Test `sly-inside-string-p' returns t inside string."
+  (sly-unit-with-temp-lisp-buffer "(defvar x \"hello world\")"
+    (search-forward "hello")
+    (should (sly-inside-string-p))))
+
+(ert-deftest sly-parse-unit--inside-string-p-no ()
+  "Test `sly-inside-string-p' returns nil outside string."
+  (sly-unit-with-temp-lisp-buffer "(defvar x \"hello world\")"
+    (search-forward "defvar")
+    (should-not (sly-inside-string-p))))
+
+(ert-deftest sly-parse-unit--inside-string-p-at-quote ()
+  "Test `sly-inside-string-p' at opening quote."
+  (sly-unit-with-temp-lisp-buffer "(defvar x \"hello\")"
+    (search-forward "\"")
+    (backward-char 1)
+    (should-not (sly-inside-string-p))))
+
+;;;; Tests for sly-inside-comment-p
+;;;;
+(ert-deftest sly-parse-unit--inside-comment-p-line-comment ()
+  "Test `sly-inside-comment-p' in line comment."
+  (sly-unit-with-temp-lisp-buffer "(foo) ; this is a comment\n(bar)"
+    (search-forward "this")
+    (should (sly-inside-comment-p))))
+
+(ert-deftest sly-parse-unit--inside-comment-p-block-comment ()
+  "Test `sly-inside-comment-p' in block comment."
+  (sly-unit-with-temp-lisp-buffer "(foo) #| block comment |# (bar)"
+    (search-forward "block")
+    (should (sly-inside-comment-p))))
+
+(ert-deftest sly-parse-unit--inside-comment-p-no ()
+  "Test `sly-inside-comment-p' returns nil in code."
+  (sly-unit-with-temp-lisp-buffer "(foo) ; comment\n(bar)"
+    (search-forward "bar")
+    (should-not (sly-inside-comment-p))))
+
+;;;; Tests for sly-inside-string-or-comment-p
+;;;;
+(ert-deftest sly-parse-unit--inside-string-or-comment-p-string ()
+  "Test `sly-inside-string-or-comment-p' in string."
+  (sly-unit-with-temp-lisp-buffer "(print \"hello\")"
+    (search-forward "hello")
+    (should (sly-inside-string-or-comment-p))))
+
+(ert-deftest sly-parse-unit--inside-string-or-comment-p-comment ()
+  "Test `sly-inside-string-or-comment-p' in comment."
+  (sly-unit-with-temp-lisp-buffer "(print x) ; comment"
+    (search-forward "comment")
+    (should (sly-inside-string-or-comment-p))))
+
+(ert-deftest sly-parse-unit--inside-string-or-comment-p-no ()
+  "Test `sly-inside-string-or-comment-p' in code."
+  (sly-unit-with-temp-lisp-buffer "(print x)"
+    (search-forward "print")
+    (should-not (sly-inside-string-or-comment-p))))
+
+;;;; Tests for sly-beginning-of-list
+;;;;
+(ert-deftest sly-parse-unit--beginning-of-list-simple ()
+  "Test `sly-beginning-of-list' moves to first element."
+  (sly-unit-with-temp-lisp-buffer "(foo bar baz)"
+    (goto-char (point-max))
+    (backward-char 2)  ; point at 'z' in baz
+    (sly-beginning-of-list)
+    (should (looking-at "foo"))))
+
+(ert-deftest sly-parse-unit--beginning-of-list-nested ()
+  "Test `sly-beginning-of-list' in nested list."
+  (sly-unit-with-temp-lisp-buffer "(outer (inner x y))"
+    (search-forward "y")
+    (sly-beginning-of-list)
+    (should (looking-at "inner"))))
+
+(ert-deftest sly-parse-unit--beginning-of-list-with-up ()
+  "Test `sly-beginning-of-list' with UP argument."
+  (sly-unit-with-temp-lisp-buffer "(a (b (c x)))"
+    (search-forward "x")
+    (sly-beginning-of-list 2)
+    (should (looking-at "b"))))
+
+;;;; Tests for sly-end-of-list
+;;;;
+(ert-deftest sly-parse-unit--end-of-list-simple ()
+  "Test `sly-end-of-list' moves past last element."
+  (sly-unit-with-temp-lisp-buffer "(foo bar baz)"
+    (forward-char 1)  ; inside the list
+    (sly-end-of-list)
+    (should (looking-back "baz" (- (point) 5)))))
+
+;;;; Tests for sly-in-expression-p
+;;;;
+(ert-deftest sly-parse-unit--in-expression-p-empty-pattern ()
+  "Test `sly-in-expression-p' with empty pattern matches anywhere."
+  (sly-unit-with-temp-lisp-buffer "(anything here)"
+    (search-forward "here")
+    (should (sly-in-expression-p '()))))
+
+(ert-deftest sly-parse-unit--in-expression-p-star ()
+  "Test `sly-in-expression-p' with (*) matches inside list."
+  (sly-unit-with-temp-lisp-buffer "(something)"
+    (search-forward "some")
+    (should (sly-in-expression-p '(*)))))
+
+(ert-deftest sly-parse-unit--in-expression-p-defun ()
+  "Test `sly-in-expression-p' matches defun."
+  (sly-unit-with-temp-lisp-buffer "(defun foo () nil)"
+    (search-forward "foo")
+    (should (sly-in-expression-p '(defun *)))))
+
+(ert-deftest sly-parse-unit--in-expression-p-defun-negative ()
+  "Test `sly-in-expression-p' doesn't match wrong form."
+  (sly-unit-with-temp-lisp-buffer "(defvar foo nil)"
+    (search-forward "foo")
+    (should-not (sly-in-expression-p '(defun *)))))
+
+(ert-deftest sly-parse-unit--in-expression-p-defmethod ()
+  "Test `sly-in-expression-p' matches defmethod."
+  (sly-unit-with-temp-lisp-buffer "(defmethod print-object ((obj foo) stream) nil)"
+    (search-forward "print-object")
+    (should (sly-in-expression-p '(defmethod *)))))
+
+(ert-deftest sly-parse-unit--in-expression-p-labels ()
+  "Test `sly-in-expression-p' matches labels with nested pattern."
+  (sly-unit-with-temp-lisp-buffer "(defun outer ()
+  (labels ((inner (x) x))
+    (inner 1)))"
+    (search-forward "inner (x)")
+    (should (sly-in-expression-p '(labels ((*)))))))
+
+;;;; Tests for sly-parse-form-until
+;;;;
+(ert-deftest sly-parse-unit--parse-form-until-simple ()
+  "Test `sly-parse-form-until' parses simple form."
+  (sly-unit-with-temp-lisp-buffer "(foo bar baz)"
+    (forward-char 1)  ; after opening paren
+    (let ((result (sly-parse-form-until (point-max) '(CURSOR))))
+      (should (member "foo" result))
+      (should (member "bar" result))
+      (should (member "baz" result))
+      (should (member 'CURSOR result)))))
+
+(ert-deftest sly-parse-unit--parse-form-until-partial ()
+  "Test `sly-parse-form-until' parses partial form."
+  (sly-unit-with-temp-lisp-buffer "(foo bar baz)"
+    (forward-char 1)
+    (let ((result (sly-parse-form-until 8 '(CURSOR))))  ; up to 'bar'
+      (should (member "foo" result))
+      (should (member 'CURSOR result)))))
+
+;;;; Tests for sly-current-parser-state
+;;;;
+(ert-deftest sly-parse-unit--current-parser-state-at-top ()
+  "Test `sly-current-parser-state' at top level."
+  (sly-unit-with-temp-lisp-buffer "(foo)"
+    ;; At top level, depth should be 0
+    (should (zerop (car (sly-current-parser-state))))))
+
+(ert-deftest sly-parse-unit--current-parser-state-in-list ()
+  "Test `sly-current-parser-state' inside list."
+  (sly-unit-with-temp-lisp-buffer "(foo bar)"
+    (forward-char 1)  ; inside list
+    (should (= 1 (car (sly-current-parser-state))))))
+
+(ert-deftest sly-parse-unit--current-parser-state-nested ()
+  "Test `sly-current-parser-state' in nested list."
+  (sly-unit-with-temp-lisp-buffer "(foo (bar baz))"
+    (search-forward "bar")
+    (should (= 2 (car (sly-current-parser-state))))))
+
+(provide 'sly-parse-unit-tests)
+;;; sly-parse-unit-tests.el ends here

--- a/test/sly-test-coverage.el
+++ b/test/sly-test-coverage.el
@@ -1,0 +1,40 @@
+;;; sly-test-coverage.el --- Coverage setup for SLY tests -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 SLY Contributors
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; Commentary:
+
+;; Code coverage configuration for SLY using undercover.el.
+;; This file should be loaded before running tests to enable coverage tracking.
+;;
+;; Usage:
+;;   make check-unit-coverage    # Run unit tests with coverage
+;;   make check-coverage         # Run all tests with coverage
+;;
+;; Coverage reports are generated in coverage/ directory.
+
+;;; Code:
+
+(when (require 'undercover nil t)
+  (undercover "sly.el"
+              ;; Core library files
+              "lib/sly-parse.el"
+              "lib/sly-completion.el"
+              "lib/sly-buttons.el"
+              "lib/sly-messages.el"
+              "lib/sly-common.el"
+              "lib/sly-cl-indent.el"
+              ;; Contrib files (optional - comment out if too slow)
+              (:exclude "contrib/sly-*.el")
+              ;; Report configuration
+              (:report-format 'codecov)
+              (:report-file "coverage/codecov.json")
+              (:send-report nil)))  ; Don't auto-send, CI will handle upload
+
+(provide 'sly-test-coverage)
+;;; sly-test-coverage.el ends here

--- a/test/sly-test-mocks.el
+++ b/test/sly-test-mocks.el
@@ -1,0 +1,202 @@
+;;; sly-test-mocks.el --- Mock objects for SLY unit tests -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 SLY Contributors
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; Commentary:
+
+;; This file provides mock objects and utilities for testing SLY
+;; functionality without requiring an actual Lisp connection.
+;;
+;; WHAT THIS FILE PROVIDES:
+;;
+;; When testing SLY code that calls sly-eval, sly-eval-async, or checks
+;; connection status, this module provides mocks so tests don't need a
+;; real Lisp server running.  Mocks integrate with the test framework
+;; to verify which functions were called and with what arguments.
+;;
+;; KEY UTILITIES:
+;;
+;; Mock Setup:
+;;   - sly-test-with-mock-eval: Execute code with mocked sly-eval responses
+;;   - sly-test-with-mock-connection: Set up mock connection without eval
+;;
+;; Mock Responses:
+;;   - sly-test-mock--responses: Registry of (REQUEST . RESPONSE) pairs
+;;   - sly-test-mock-eval: Mock implementation of sly-eval
+;;   - sly-test-mock-eval-async: Mock implementation of sly-eval-async
+;;
+;; Mock Connection:
+;;   - sly-test-mock-make-connection: Create a mock connection object
+;;   - sly-test-mock-connected-p: Mock sly-connected-p
+;;   - sly-test-mock-current-package: Mock sly-current-package
+;;
+;; Verification:
+;;   - sly-test-mock-assert-called: Verify function was called
+;;   - sly-test-mock-assert-called-with: Verify function was called with args
+;;   - sly-test-mock--calls-to: Get all calls to a function
+;;
+;; USAGE PATTERN:
+;;
+;; (ert-deftest sly-example-unit--completion-with-mock-eval ()
+;;   "Test completion when Lisp returns suggestions."
+;;   (sly-test-with-mock-eval
+;;       (((slynk:simple-completions \"foo\" \"CL-USER\")
+;;         . ((\"foobar\" \"foobaz\") \"foo\")))
+;;     (let ((result (sly-eval '(slynk:simple-completions \"foo\" \"CL-USER\"))))
+;;       (should (equal '(\"foobar\" \"foobaz\") (car result))))))
+;;
+;; For complete examples, see doc/TESTING-UNIT-TESTS.md.
+
+;;; Code:
+
+(require 'cl-lib)
+
+;; Forward declarations to avoid requiring sly.el during unit tests
+(defvar sly-buffer-package)
+(defvar sly-buffer-connection)
+
+;;; Mock Response Registry
+;;;
+(defvar sly-test-mock--responses nil
+  "Alist of (REQUEST . RESPONSE) for mock evaluations.
+Each REQUEST is compared with `equal' to incoming sexp.")
+
+(defvar sly-test-mock--call-log nil
+  "List of calls made to mock functions, most recent first.
+Each entry is (FUNCTION-NAME . ARGS).")
+
+(defun sly-test-mock--reset ()
+  "Reset all mock state."
+  (setq sly-test-mock--responses nil
+        sly-test-mock--call-log nil))
+
+(defun sly-test-mock--log-call (fn &rest args)
+  "Log a call to FN with ARGS."
+  (push (cons fn args) sly-test-mock--call-log))
+
+(defun sly-test-mock--calls-to (fn)
+  "Return list of calls made to FN."
+  (cl-remove-if-not (lambda (entry) (eq (car entry) fn))
+                    sly-test-mock--call-log))
+
+;;; Mock sly-eval Implementation
+;;;
+(defun sly-test-mock--find-response (sexp)
+  "Find a mock response for SEXP.
+Returns the response or signals an error if not found."
+  (let ((entry (cl-find-if
+                (lambda (pair)
+                  (let ((pattern (car pair)))
+                    (if (functionp pattern)
+                        (funcall pattern sexp)
+                      (equal pattern sexp))))
+                sly-test-mock--responses)))
+    (if entry
+        (let ((response (cdr entry)))
+          (if (functionp response)
+              (funcall response sexp)
+            response))
+      (error "No mock response registered for: %S" sexp))))
+
+(defun sly-test-mock-eval (sexp &optional _package _cancel-on-input _cancel-retval)
+  "Mock implementation of `sly-eval'.
+Looks up SEXP in `sly-test-mock--responses' and returns the response."
+  (sly-test-mock--log-call 'sly-eval sexp)
+  (sly-test-mock--find-response sexp))
+
+(defun sly-test-mock-eval-async (sexp cont &optional _package)
+  "Mock implementation of `sly-eval-async'.
+Immediately calls CONT with the mock response for SEXP."
+  (sly-test-mock--log-call 'sly-eval-async sexp)
+  (funcall cont (sly-test-mock--find-response sexp)))
+
+;;; Mock Connection
+;;;
+(defvar sly-test-mock--connection-counter 0
+  "Counter for generating unique mock connection IDs.")
+
+(cl-defstruct (sly-test-mock-connection
+               (:constructor sly-test-mock-connection--create))
+  "A mock SLY connection for testing."
+  (id (cl-incf sly-test-mock--connection-counter))
+  (pid 99999)
+  (implementation-type "MockLisp")
+  (implementation-name "mock")
+  (implementation-version "1.0.0")
+  (machine-type "test-machine")
+  (features '(:mock-lisp))
+  (package "CL-USER"))
+
+(defun sly-test-mock-make-connection ()
+  "Create a new mock connection."
+  (sly-test-mock-connection--create))
+
+;;; Mock Connection Functions
+;;;
+(defun sly-test-mock-connected-p ()
+  "Mock implementation of `sly-connected-p'."
+  t)
+
+(defun sly-test-mock-current-connection ()
+  "Mock implementation of `sly-current-connection'."
+  'mock-connection)
+
+(defun sly-test-mock-current-package ()
+  "Mock implementation of `sly-current-package'."
+  (or (bound-and-true-p sly-buffer-package) "CL-USER"))
+
+;;; Setup Macro
+;;;
+(defmacro sly-test-with-mock-eval (responses &rest body)
+  "Execute BODY with mock evaluation returning RESPONSES.
+RESPONSES is an alist of (SEXP . RESULT) pairs.
+SEXP can be a literal form or a predicate function.
+RESULT can be a value or a function that receives the sexp.
+
+Example:
+  (sly-test-with-mock-eval
+      (((slynk:connection-info) . (:pid 1234 :version \"1.0\"))
+       ((slynk:simple-completions \"foo\" \"CL-USER\")
+        . ((\"foobar\" \"foobaz\") \"foo\")))
+    (sly-eval \\='(slynk:connection-info)))"
+  (declare (indent 1) (debug t))
+  `(let ((sly-test-mock--responses ',responses)
+         (sly-test-mock--call-log nil))
+     (cl-letf (((symbol-function 'sly-eval) #'sly-test-mock-eval)
+               ((symbol-function 'sly-eval-async) #'sly-test-mock-eval-async)
+               ((symbol-function 'sly-connected-p) #'sly-test-mock-connected-p)
+               ((symbol-function 'sly-current-connection) #'sly-test-mock-current-connection)
+               ((symbol-function 'sly-current-package) #'sly-test-mock-current-package))
+       (let ((sly-buffer-package "CL-USER")
+             (sly-buffer-connection 'mock-connection))
+         ,@body))))
+
+(defmacro sly-test-with-mock-connection (&rest body)
+  "Execute BODY with a mock connection available but no eval responses.
+Use this for testing code that only checks connection status."
+  (declare (indent 0) (debug t))
+  `(sly-test-with-mock-eval nil ,@body))
+
+;;; Assertion Helpers for Mocks
+;;;
+(defun sly-test-mock-assert-called (fn &optional times)
+  "Assert that FN was called, optionally exactly TIMES times."
+  (let ((calls (sly-test-mock--calls-to fn)))
+    (if times
+        (should (= (length calls) times))
+      (should calls))))
+
+(defun sly-test-mock-assert-called-with (fn expected-args)
+  "Assert that FN was called with EXPECTED-ARGS at least once."
+  (let ((calls (sly-test-mock--calls-to fn)))
+    (should (cl-find expected-args calls
+                     :test #'equal
+                     :key #'cdr))))
+
+(provide 'sly-test-mocks)
+;;; sly-test-mocks.el ends here

--- a/test/sly-xref-unit-tests.el
+++ b/test/sly-xref-unit-tests.el
@@ -1,0 +1,384 @@
+;;; sly-xref-unit-tests.el --- Unit tests for sly-xref.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 SLY Contributors
+
+;;; Commentary:
+
+;; Unit tests for the xref.el integration in lib/sly-xref.el.
+;; Tests cover location conversion, backend methods, and query functionality.
+;;
+;; WHAT IS TESTED:
+;;
+;; This module tests SLY's integration with Emacs's xref.el framework.
+;; The integration allows standard M-. / M-, navigation to work with
+;; Common Lisp definitions via the Slynk server.
+;;
+;; KEY FUNCTIONS TESTED:
+;;
+;; Location Conversion:
+;;   sly-xref--convert-to-xref-items: Convert Slynk results to xref objects
+;;   sly-xref--convert-location: Convert single Slynk location
+;;   sly-xref--make-location: Create xref location from buffer/position specs
+;;   sly-xref--position-to-line-col: Byte position to line/column
+;;   sly-xref--resolve-position-in-file: Handle different position types
+;;
+;; Backend Methods:
+;;   xref-backend-identifier-at-point: Get symbol at point
+;;   xref-backend-definitions: Find definitions
+;;   xref-backend-references: Find references
+;;   xref-backend-apropos: Pattern-based symbol search
+;;
+;; Query System:
+;;   sly-xref-query: Unified query command for all xref types
+;;   sly-xref-query-types: Registry of query type keywords
+;;
+;; WHAT IS COVERED:
+;;
+;; Location Conversion:
+;;   - File locations with byte positions
+;;   - File locations with line/column
+;;   - Buffer locations
+;;   - Error/bogus locations
+;;   - Position types: :position, :offset, :line, :function-name
+;;
+;; Backend Protocol:
+;;   - Backend registration via xref-backend-functions
+;;   - Identifier extraction at point
+;;   - Definition lookup with mock responses
+;;   - Reference lookup with mock responses
+;;   - Handling :not-implemented responses
+;;
+;; Query Types:
+;;   - All supported types: :calls, :calls-who, :references, etc.
+;;   - Error handling for unimplemented queries
+;;   - Empty result handling
+;;
+;; WHEN TO ADD TESTS:
+;;
+;; Add tests when modifying:
+;;   - Location conversion logic
+;;   - Backend method implementations
+;;   - Query type handling
+;;   - Error cases and edge conditions
+;;
+;; WHY UNIT TESTS:
+;;
+;; The xref integration has many edge cases in location conversion
+;; (different position types, file vs buffer, errors) that need testing
+;; without a running Lisp server. These tests verify the conversion
+;; logic is correct before integration testing.
+;;
+;; See doc/TESTING-UNIT-TESTS.md for patterns and utilities.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'xref)
+(require 'sly-test-mocks "test/sly-test-mocks")
+
+;; Forward declarations - actual implementation will be in lib/sly-xref.el
+(declare-function sly-xref--convert-to-xref-items "lib/sly-xref")
+(declare-function sly-xref--convert-location "lib/sly-xref")
+(declare-function sly-xref--make-location "lib/sly-xref")
+(declare-function sly-xref--position-to-line-col "lib/sly-xref")
+(declare-function sly-xref--resolve-position-in-file "lib/sly-xref")
+(declare-function sly-xref-backend "lib/sly-xref")
+(declare-function sly-xref-query "lib/sly-xref")
+
+;; Load the module under test when available
+(when (locate-library "sly-xref" nil (list (expand-file-name "lib" (file-name-directory load-file-name)))))
+
+;;;; Location Conversion Tests
+;;;;
+
+(ert-deftest sly-xref-unit--convert-file-location-with-position ()
+  "Test conversion of Slynk file location with :position to xref."
+  (skip-unless (fboundp 'sly-xref--convert-location))
+  (let* ((slynk-loc '(:location (:file "/tmp/test.lisp")
+                                (:position 100)
+                                (:snippet "(defun foo")))
+         (xref-loc (sly-xref--convert-location slynk-loc)))
+    (should xref-loc)
+    (should (xref-file-location-p xref-loc))))
+
+(ert-deftest sly-xref-unit--convert-file-location-with-line ()
+  "Test conversion of Slynk file location with :line to xref."
+  (skip-unless (fboundp 'sly-xref--convert-location))
+  (let* ((slynk-loc '(:location (:file "/tmp/test.lisp")
+                                (:line 10 5)
+                                nil))
+         (xref-loc (sly-xref--convert-location slynk-loc)))
+    (should xref-loc)
+    (should (xref-file-location-p xref-loc))
+    (should (= 10 (xref-file-location-line xref-loc)))
+    ;; xref.el uses 0-based columns; input column 5 (1-based) = column 4 (0-based)
+    (should (= 4 (xref-file-location-column xref-loc)))))
+
+(ert-deftest sly-xref-unit--convert-buffer-location ()
+  "Test conversion of Slynk buffer location to xref."
+  (skip-unless (fboundp 'sly-xref--convert-location))
+  (with-temp-buffer
+    (rename-buffer "*test-buffer*" t)
+    (insert "(defun foo () 42)")
+    (let* ((buf-name (buffer-name))
+           (slynk-loc `(:location (:buffer ,buf-name)
+                                  (:position 8)
+                                  nil))
+           (xref-loc (sly-xref--convert-location slynk-loc)))
+      (should xref-loc)
+      (should (xref-buffer-location-p xref-loc)))))
+
+(ert-deftest sly-xref-unit--convert-error-location ()
+  "Test conversion of Slynk error location to bogus xref."
+  (skip-unless (fboundp 'sly-xref--convert-location))
+  (let* ((slynk-loc '(:error "Source not available"))
+         (xref-loc (sly-xref--convert-location slynk-loc)))
+    (should xref-loc)
+    (should (xref-bogus-location-p xref-loc))
+    (should (string-match "Source not available"
+                          (xref-bogus-location-message xref-loc)))))
+
+(ert-deftest sly-xref-unit--convert-source-form-location ()
+  "Test conversion of :source-form location (no file) to bogus xref."
+  (skip-unless (fboundp 'sly-xref--convert-location))
+  (let* ((slynk-loc '(:location (:source-form "(defun foo () 42)")
+                                (:position 1)
+                                nil))
+         (xref-loc (sly-xref--convert-location slynk-loc)))
+    (should xref-loc)
+    (should (xref-bogus-location-p xref-loc))))
+
+(ert-deftest sly-xref-unit--convert-nil-location ()
+  "Test that nil location returns nil."
+  (skip-unless (fboundp 'sly-xref--convert-location))
+  (should-not (sly-xref--convert-location nil)))
+
+(ert-deftest sly-xref-unit--convert-multiple-xrefs ()
+  "Test conversion of multiple Slynk xrefs to xref-items."
+  (skip-unless (fboundp 'sly-xref--convert-to-xref-items))
+  (let* ((slynk-xrefs
+          '(("(defun foo)" (:location (:file "/tmp/a.lisp") (:line 10) nil))
+            ("(defun bar)" (:location (:file "/tmp/b.lisp") (:line 20) nil))
+            ("(defmethod foo)" (:error "Compiled code"))))
+         (xref-items (sly-xref--convert-to-xref-items slynk-xrefs)))
+    (should (= 3 (length xref-items)))
+    (should (cl-every #'xref-item-p xref-items))
+    ;; First two have real locations, third has bogus
+    (should (xref-file-location-p (xref-item-location (nth 0 xref-items))))
+    (should (xref-file-location-p (xref-item-location (nth 1 xref-items))))
+    (should (xref-bogus-location-p (xref-item-location (nth 2 xref-items))))))
+
+;;;; Position Resolution Tests
+;;;;
+
+(ert-deftest sly-xref-unit--position-to-line-col-basic ()
+  "Test byte position to line/column conversion."
+  (skip-unless (fboundp 'sly-xref--position-to-line-col))
+  (let ((temp-file (make-temp-file "sly-xref-test" nil ".lisp")))
+    (unwind-protect
+        (progn
+          (with-temp-file temp-file
+            (insert "(defun foo ()\n")  ; line 1: 15 chars
+            (insert "  42)\n"))          ; line 2: 6 chars
+          (let ((line-col (sly-xref--position-to-line-col
+                           temp-file '(:position 18))))
+            ;; Position 18 is "4" on line 2
+            (should (equal 2 (car line-col)))))
+      (delete-file temp-file))))
+
+(ert-deftest sly-xref-unit--position-to-line-col-line-spec ()
+  "Test :line position spec passes through correctly."
+  (skip-unless (fboundp 'sly-xref--position-to-line-col))
+  (let ((temp-file (make-temp-file "sly-xref-test" nil ".lisp")))
+    (unwind-protect
+        (progn
+          (with-temp-file temp-file
+            (insert "line1\nline2\nline3\n"))
+          (let ((line-col (sly-xref--position-to-line-col
+                           temp-file '(:line 2 3))))
+            (should (equal 2 (car line-col)))
+            ;; xref.el uses 0-based columns; input column 3 (1-based) = column 2 (0-based)
+            (should (equal 2 (cdr line-col)))))
+      (delete-file temp-file))))
+
+(ert-deftest sly-xref-unit--position-to-line-col-function-name ()
+  "Test :function-name position spec finds function."
+  (skip-unless (fboundp 'sly-xref--resolve-position-in-file))
+  (let ((temp-file (make-temp-file "sly-xref-test" nil ".lisp")))
+    (unwind-protect
+        (progn
+          (with-temp-file temp-file
+            (insert "(defpackage :test)\n")
+            (insert "(defun my-special-function ()\n")
+            (insert "  42)\n"))
+          (let ((pos (sly-xref--resolve-position-in-file
+                      temp-file '(:function-name "my-special-function"))))
+            ;; Should find the function name
+            (should (> pos 20))))
+      (delete-file temp-file))))
+
+(ert-deftest sly-xref-unit--position-to-line-col-error-fallback ()
+  "Test that position conversion falls back gracefully on errors."
+  (skip-unless (fboundp 'sly-xref--position-to-line-col))
+  ;; Non-existent file should return (1 . 0)
+  (let ((line-col (sly-xref--position-to-line-col
+                   "/nonexistent/file.lisp" '(:position 100))))
+    (should (equal '(1 . 0) line-col))))
+
+;;;; Backend Registration Tests
+;;;;
+
+(ert-deftest sly-xref-unit--backend-returns-sly-when-connected ()
+  "Test that backend function returns 'sly when connected."
+  (skip-unless (fboundp 'sly-xref-backend))
+  (sly-test-with-mock-connection
+    (should (eq 'sly (sly-xref-backend)))))
+
+(ert-deftest sly-xref-unit--backend-returns-nil-when-disconnected ()
+  "Test that backend function returns nil when not connected."
+  (skip-unless (fboundp 'sly-xref-backend))
+  ;; Without mock connection, sly-connected-p returns nil
+  (cl-letf (((symbol-function 'sly-connected-p) (lambda () nil)))
+    (should-not (sly-xref-backend))))
+
+;;;; Backend Method Tests
+;;;;
+
+(ert-deftest sly-xref-unit--backend-definitions-basic ()
+  "Test xref-backend-definitions with mock eval."
+  (skip-unless (fboundp 'xref-backend-definitions))
+  (sly-test-with-mock-eval
+      (((slynk:find-definitions-for-emacs "foo")
+        . (("(defun foo)" (:location (:file "/tmp/test.lisp") (:line 10) nil)))))
+    (let ((xrefs (xref-backend-definitions 'sly "foo")))
+      (should (listp xrefs))
+      (should (= 1 (length xrefs)))
+      (should (xref-item-p (car xrefs)))
+      (should (string-match "defun foo" (xref-item-summary (car xrefs)))))))
+
+(ert-deftest sly-xref-unit--backend-definitions-no-results ()
+  "Test xref-backend-definitions with no results."
+  (skip-unless (fboundp 'xref-backend-definitions))
+  (sly-test-with-mock-eval
+      (((slynk:find-definitions-for-emacs "nonexistent") . nil))
+    (let ((xrefs (xref-backend-definitions 'sly "nonexistent")))
+      (should (null xrefs)))))
+
+(ert-deftest sly-xref-unit--backend-references-basic ()
+  "Test xref-backend-references with mock eval."
+  (skip-unless (fboundp 'xref-backend-references))
+  (sly-test-with-mock-eval
+      (((slynk:xref ':callers "foo")
+        . (("(defun bar)" (:location (:file "/tmp/bar.lisp") (:line 5) nil)))))
+    (let ((xrefs (xref-backend-references 'sly "foo")))
+      (should (listp xrefs))
+      (should (= 1 (length xrefs))))))
+
+(ert-deftest sly-xref-unit--backend-references-not-implemented ()
+  "Test xref-backend-references when Lisp returns :not-implemented."
+  (skip-unless (fboundp 'xref-backend-references))
+  (sly-test-with-mock-eval
+      (((slynk:xref ':callers "foo") . :not-implemented))
+    (let ((xrefs (xref-backend-references 'sly "foo")))
+      (should (null xrefs)))))
+
+(ert-deftest sly-xref-unit--backend-apropos-basic ()
+  "Test xref-backend-apropos with mock eval."
+  (skip-unless (fboundp 'xref-backend-apropos))
+  (sly-test-with-mock-eval
+      (((slynk:apropos-list-for-emacs "foo" nil nil)
+        . (("FOO" 0 (:function :variable))
+           ("FOOBAR" 0 (:function)))))
+    (let ((xrefs (xref-backend-apropos 'sly "foo")))
+      (should (listp xrefs))
+      (should (= 2 (length xrefs)))
+      ;; Apropos returns bogus locations (no source info)
+      (should (xref-bogus-location-p (xref-item-location (car xrefs)))))))
+
+;;;; Query System Tests
+;;;;
+
+(ert-deftest sly-xref-unit--query-calls ()
+  "Test sly-xref-query with :calls type."
+  (skip-unless (fboundp 'sly-xref-query))
+  (sly-test-with-mock-eval
+      ;; Note: sly-xref-query uses `(slynk:xref ',type ',symbol) which quotes args
+      (((slynk:xref ':calls '"foo")
+        . (("(defun bar)" (:location (:file "/tmp/bar.lisp") (:line 5) nil)))))
+    ;; Just verify it doesn't error - actual display is side effect
+    (should-not (condition-case err
+                    (progn
+                      (cl-letf (((symbol-function 'xref-show-xrefs)
+                                 (lambda (fetcher _display-action)
+                                   (funcall fetcher))))
+                        (sly-xref-query :calls "foo"))
+                      nil)
+                  (error err)))))
+
+(ert-deftest sly-xref-unit--query-not-implemented ()
+  "Test sly-xref-query when Lisp returns :not-implemented."
+  (skip-unless (fboundp 'sly-xref-query))
+  (sly-test-with-mock-eval
+      ;; Note: sly-xref-query uses `(slynk:xref ',type ',symbol) which quotes args
+      (((slynk:xref ':binds '"foo") . :not-implemented))
+    ;; Should message, not error
+    (cl-letf (((symbol-function 'sly-lisp-implementation-name)
+               (lambda () "MockLisp")))
+      (should-not (condition-case err
+                      (progn (sly-xref-query :binds "foo") nil)
+                    (error err))))))
+
+(ert-deftest sly-xref-unit--query-all-types-registered ()
+  "Test that all expected query types are registered."
+  (skip-unless (boundp 'sly-xref-query-types))
+  (let ((expected-types '(:calls :calls-who :references :binds :sets
+                          :macroexpands :specializes :callers :callees)))
+    (dolist (type expected-types)
+      (should (cl-find type sly-xref-query-types :key #'cdr)))))
+
+;;;; Recompile Mode Tests
+;;;;
+
+(ert-deftest sly-xref-unit--recompile-mode-map-defined ()
+  "Test that recompile mode keymap has expected bindings."
+  (skip-unless (boundp 'sly-xref-recompile-mode-map))
+  (should (keymapp sly-xref-recompile-mode-map))
+  (should (lookup-key sly-xref-recompile-mode-map (kbd "C-c C-c")))
+  (should (lookup-key sly-xref-recompile-mode-map (kbd "C-c C-k"))))
+
+;;;; Backward Compatibility Tests
+;;;;
+
+(ert-deftest sly-xref-unit--deprecated-edit-definition-works ()
+  "Test that deprecated sly-edit-definition still works."
+  (skip-unless (fboundp 'sly-edit-definition))
+  (sly-test-with-mock-eval
+      (((slynk:find-definitions-for-emacs "car")
+        . (("(defun car)" (:location (:file "/tmp/cl.lisp") (:line 1) nil)))))
+    ;; Should not error
+    (cl-letf (((symbol-function 'xref-push-marker-stack) #'ignore)
+              ((symbol-function 'xref-pop-marker-stack) #'ignore)
+              ((symbol-function 'xref-show-xrefs)
+               (lambda (fetcher _action) (funcall fetcher)))
+              ((symbol-function 'sly--pop-to-source-location) #'ignore))
+      (should-not (condition-case err
+                      (progn (sly-edit-definition "car") nil)
+                    (error err))))))
+
+(ert-deftest sly-xref-unit--deprecated-who-calls-works ()
+  "Test that deprecated sly-who-calls still works via sly-xref."
+  (skip-unless (fboundp 'sly-who-calls))
+  (sly-test-with-mock-eval
+      ;; Note: sly-xref uses `(slynk:xref ',type ',symbol) which quotes args
+      (((slynk:xref ':calls '"foo")
+        . (("(defun bar)" (:location (:file "/tmp/bar.lisp") (:line 5) nil)))))
+    (cl-letf (((symbol-function 'sly-xref--show-results)
+               (lambda (&rest _args) t)))
+      (should-not (condition-case err
+                      (progn (sly-who-calls "foo") nil)
+                    (error err))))))
+
+(provide 'sly-xref-unit-tests)
+
+;;; sly-xref-unit-tests.el ends here


### PR DESCRIPTION
Summary

  This PR integrates SLY with Emacs's built-in xref.el framework, providing standard cross-reference navigation while maintaining full backward compatibility with existing commands.

  What This Changes

  User-facing:
  - Standard Emacs navigation commands (M-., M-,, M-?) now work with SLY
  - New unified command sly-xref-query for accessing all xref types (calls, references, binds, sets, etc.)
  - Xref results display in standard *xref* buffer with recompilation support
  - All existing sly-edit-definition, sly-who-calls, etc. commands continue to work (soft-deprecated)

  Implementation:
  - New lib/sly-xref.el backend that registers with xref-backend-functions
  - Location conversion between Slynk's format and xref.el's expectations
  - Minor mode for recompiling definitions from xref buffers (C-c C-c, C-c C-k)

  Files Changed

  New files:
  - lib/sly-xref.el - xref.el backend implementation (379 lines)
  - test/sly-xref-unit-tests.el - 24 unit tests
  - doc/XREF-COMPARISON.md - Architecture comparison
  - doc/plans/2026-01-02-xref-integration-design.md - Design document
  - doc/XREF-INTEGRATION-CHANGES.md - Change report

  Modified files:
  - sly.el - Added require for sly-xref.el, soft-deprecation notes
  - Makefile - Added xref tests to check-unit target

  Test Coverage

  - 165 total unit tests pass (141 existing + 24 new)
  - New tests cover:
    - Backend registration and methods
    - Location conversion (file, buffer, error, source-form)
    - Position resolution (byte offsets, line specs, function names)
    - Query system (all xref types)
    - Backward compatibility (old commands still work)
    - Recompile mode

  Design Decisions

  | Decision               | Choice                                                   |
  |------------------------|----------------------------------------------------------|
  | Backward compatibility | Soft deprecation - old commands work, new ones preferred |
  | Async handling         | Synchronous (Slynk queries are fast, <100ms)             |
  | Extended xref types    | Unified sly-xref-query command                           |
  | Recompile feature      | Minor mode on xref buffers                               |

  Migration Impact

  Zero breaking changes. Users can:
  - Continue using existing workflows without modification
  - Gradually adopt standard Emacs keybindings (M-. vs M-x sly-edit-definition)
  - Use new unified sly-xref-query for advanced cross-reference queries

  Benefits

  1. Consistency: Works like other Emacs modes (LSP, etags, etc.)
  2. Integration: Compatible with project.el, grep.el, and xref ecosystem
  3. Maintenance: Leverages Emacs core improvements; less custom code
  4. Future-proof: Other packages expect xref.el integration

  Documentation

  All changes documented in:
  - doc/XREF-COMPARISON.md - Technical comparison
  - doc/plans/2026-01-02-xref-integration-design.md - Implementation design
  - doc/XREF-INTEGRATION-CHANGES.md - Complete change log